### PR TITLE
Add metadata index decoding for song data

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,189 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 
 # ============================================================================
+# 인덱스 정의
+# ============================================================================
+
+SUBGENRES: List[str] = [
+    "alt_pop",
+    "alternative_hip_hop",
+    "alternative_r&b",
+    "alternative_rock",
+    "ambient",
+    "art_pop",
+    "blues_rock",
+    "chamber_pop",
+    "chillhop",
+    "contemporary_jazz",
+    "cool_jazz",
+    "dance",
+    "dance_pop",
+    "disco_pop",
+    "downtempo",
+    "edm_pop",
+    "electro_house",
+    "electronic",
+    "electronica",
+    "electropop",
+    "experimental",
+    "experimental_electronic",
+    "experimental_pop",
+    "flamenco_pop",
+    "french_house",
+    "funk",
+    "future_bass",
+    "grunge",
+    "hard_rock",
+    "hip_hop",
+    "idm",
+    "indie_folk",
+    "indie_rock",
+    "instrumental_hip_hop",
+    "jazz_hop",
+    "k_indie",
+    "k_r&b",
+    "korean_hip_hop",
+    "kpop",
+    "lo_fi",
+    "modal_jazz",
+    "neo_soul",
+    "opera_rock",
+    "piano_solo",
+    "pop_ballad",
+    "pop_rock",
+    "progressive_rock",
+    "psychedelic_pop",
+    "psychedelic_rock",
+    "r&b",
+    "r&b_pop",
+    "rock",
+    "romantic_classical",
+    "soft_rock",
+    "synth_pop",
+    "synthwave",
+    "trap",
+    "trap_pop",
+    "trip_hop",
+    "uk_garage",
+    "west_coast_hip_hop",
+]
+
+MOODS: List[str] = [
+    "abstract",
+    "aggressive",
+    "angst",
+    "atmospheric",
+    "avant_garde",
+    "bold",
+    "bright",
+    "building",
+    "celebratory",
+    "cheerful",
+    "complex",
+    "confident",
+    "contemplative",
+    "danceable",
+    "dark",
+    "defiant",
+    "dramatic",
+    "dreamy",
+    "driving",
+    "dynamic",
+    "elegant",
+    "emotional",
+    "empowering",
+    "energetic",
+    "epic",
+    "ethereal",
+    "euphoric",
+    "fierce",
+    "funky",
+    "groovy",
+    "haunting",
+    "hopeful",
+    "intense",
+    "intimate",
+    "introspective",
+    "ironic",
+    "luxurious",
+    "melancholic",
+    "mellow",
+    "minimalist",
+    "modern",
+    "mysterious",
+    "mystical",
+    "nocturnal",
+    "nostalgic",
+    "passionate",
+    "peaceful",
+    "playful",
+    "powerful",
+    "raw",
+    "rebellious",
+    "reflective",
+    "relaxed",
+    "romantic",
+    "satirical",
+    "seductive",
+    "serene",
+    "smooth",
+    "sophisticated",
+    "soulful",
+    "surreal",
+    "trippy",
+    "unsettling",
+    "upbeat",
+    "uplifting",
+    "warm",
+    "whimsical",
+    "youthful",
+]
+
+LANGUAGES: List[str] = ["en", "es", "fr", "instrumental", "ko"]
+
+INSTRUMENTATIONS: List[str] = [
+    "808",
+    "bass",
+    "drums",
+    "electronic_beats",
+    "guitar",
+    "keyboards",
+    "palmas",
+    "percussion",
+    "piano",
+    "recorder",
+    "samples",
+    "saxophone",
+    "strings",
+    "synth",
+    "trumpet",
+    "vocals",
+    "vocoder",
+]
+
+REGIONALITIES: List[str] = [
+    "asia",
+    "es",
+    "eu",
+    "fr",
+    "global",
+    "jp",
+    "kr",
+    "latam",
+    "us",
+]
+
+
+def _decode_index_list(values: List[int], lookup: List[str]) -> List[str]:
+    return [lookup[v] for v in values if isinstance(v, int) and 0 <= v < len(lookup)]
+
+
+def _decode_index(value: int, lookup: List[str]) -> Optional[str]:
+    if isinstance(value, int) and 0 <= value < len(lookup):
+        return lookup[value]
+    return None
+
+# ============================================================================
 # 데이터 모델
 # ============================================================================
 
@@ -73,14 +256,32 @@ class DataLoader:
             
             songs = []
             for item in data:
+                tags_raw = item.get('tags', {})
+                tags = dict(tags_raw)
+                if 'subgenres' in tags:
+                    tags['subgenres'] = _decode_index_list(tags.get('subgenres', []), SUBGENRES)
+                if 'mood' in tags:
+                    tags['mood'] = _decode_index_list(tags.get('mood', []), MOODS)
+                if 'language' in tags:
+                    decoded_lang = _decode_index(tags.get('language'), LANGUAGES)
+                    if decoded_lang is not None:
+                        tags['language'] = decoded_lang
+                if 'instrumentation' in tags:
+                    tags['instrumentation'] = _decode_index_list(tags.get('instrumentation', []), INSTRUMENTATIONS)
+
+                popularity_raw = item.get('popularity', {})
+                popularity = dict(popularity_raw)
+                if 'regionality' in popularity:
+                    popularity['regionality'] = _decode_index_list(popularity.get('regionality', []), REGIONALITIES)
+
                 song = Song(
                     id=item['id'],
                     artist=item['artist'],
                     title=item['title'],
                     youtube_url=item.get('youtube_url', ''),
                     genres=item.get('genres', []),
-                    tags=item.get('tags', {}),
-                    popularity=item.get('popularity', {}),
+                    tags=tags,
+                    popularity=popularity,
                     meta=item.get('meta', {}),
                     clip=item.get('clip', {})
                 )

--- a/songs.json
+++ b/songs.json
@@ -4,935 +4,1849 @@
     "artist": "Queen",
     "title": "Bohemian Rhapsody",
     "youtube_url": "https://www.youtube.com/watch?v=fJ9rUzIMcZQ",
-    "clip": {"start_sec": 120, "preview_sec": 30},
-    "genres": [1, 11],
+    "clip": {
+      "start_sec": 120,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      11
+    ],
     "tags": {
-      "subgenres": ["progressive_rock", "opera_rock"],
-      "mood": ["dramatic", "epic", "emotional"],
+      "subgenres": [
+        46,
+        42
+      ],
+      "mood": [
+        16,
+        24,
+        21
+      ],
       "energy": 0.8,
       "valence": 0.6,
       "tempo_bpm": 144,
       "era_year": 1975,
-      "language": "en",
-      "instrumentation": ["piano", "guitar", "vocals", "drums"]
+      "language": 0,
+      "instrumentation": [
+        8,
+        4,
+        15,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.95,
       "yt_views": 1800000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 354, "loudness_lufs": -11.5}
+    "meta": {
+      "duration_sec": 354,
+      "loudness_lufs": -11.5
+    }
   },
   {
     "id": "song_002",
     "artist": "BTS",
     "title": "Dynamite",
     "youtube_url": "https://www.youtube.com/watch?v=gdZLi9oWNZg",
-    "clip": {"start_sec": 48, "preview_sec": 30},
-    "genres": [2, 20],
+    "clip": {
+      "start_sec": 48,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      20
+    ],
     "tags": {
-      "subgenres": ["kpop", "disco_pop"],
-      "mood": ["upbeat", "cheerful", "energetic"],
+      "subgenres": [
+        38,
+        13
+      ],
+      "mood": [
+        63,
+        9,
+        23
+      ],
       "energy": 0.9,
       "valence": 0.95,
       "tempo_bpm": 114,
       "era_year": 2020,
-      "language": "en",
-      "instrumentation": ["synth", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.92,
       "yt_views": 1500000000,
-      "regionality": ["global", "kr", "us"]
+      "regionality": [
+        4,
+        6,
+        8
+      ]
     },
-    "meta": {"duration_sec": 199, "loudness_lufs": -6.2}
+    "meta": {
+      "duration_sec": 199,
+      "loudness_lufs": -6.2
+    }
   },
   {
     "id": "song_003",
     "artist": "Radiohead",
     "title": "Creep",
     "youtube_url": "https://www.youtube.com/watch?v=XFkzRNyygfk",
-    "clip": {"start_sec": 60, "preview_sec": 30},
-    "genres": [1, 11],
+    "clip": {
+      "start_sec": 60,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      11
+    ],
     "tags": {
-      "subgenres": ["alternative_rock", "grunge"],
-      "mood": ["melancholic", "introspective", "raw"],
+      "subgenres": [
+        3,
+        27
+      ],
+      "mood": [
+        37,
+        34,
+        49
+      ],
       "energy": 0.7,
       "valence": 0.3,
       "tempo_bpm": 92,
       "era_year": 1992,
-      "language": "en",
-      "instrumentation": ["guitar", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        4,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.88,
       "yt_views": 450000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 238, "loudness_lufs": -10.8}
+    "meta": {
+      "duration_sec": 238,
+      "loudness_lufs": -10.8
+    }
   },
   {
     "id": "song_004",
     "artist": "Daft Punk",
     "title": "One More Time",
     "youtube_url": "https://www.youtube.com/watch?v=FGBhQbmPwH8",
-    "clip": {"start_sec": 30, "preview_sec": 30},
-    "genres": [3, 30],
+    "clip": {
+      "start_sec": 30,
+      "preview_sec": 30
+    },
+    "genres": [
+      3,
+      30
+    ],
     "tags": {
-      "subgenres": ["french_house", "dance"],
-      "mood": ["euphoric", "celebratory", "uplifting"],
+      "subgenres": [
+        24,
+        11
+      ],
+      "mood": [
+        26,
+        8,
+        64
+      ],
       "energy": 0.95,
       "valence": 0.9,
       "tempo_bpm": 123,
       "era_year": 2000,
-      "language": "en",
-      "instrumentation": ["synth", "vocoder", "drums", "bass"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        16,
+        2,
+        1
+      ]
     },
     "popularity": {
       "awareness_idx": 0.85,
       "yt_views": 280000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 320, "loudness_lufs": -8.5}
+    "meta": {
+      "duration_sec": 320,
+      "loudness_lufs": -8.5
+    }
   },
   {
     "id": "song_005",
     "artist": "Kendrick Lamar",
     "title": "HUMBLE.",
     "youtube_url": "https://www.youtube.com/watch?v=tvTRZJ-4EyI",
-    "clip": {"start_sec": 25, "preview_sec": 30},
-    "genres": [4, 40],
+    "clip": {
+      "start_sec": 25,
+      "preview_sec": 30
+    },
+    "genres": [
+      4,
+      40
+    ],
     "tags": {
-      "subgenres": ["west_coast_hip_hop", "trap"],
-      "mood": ["confident", "aggressive", "bold"],
+      "subgenres": [
+        60,
+        56
+      ],
+      "mood": [
+        11,
+        1,
+        5
+      ],
       "energy": 0.85,
       "valence": 0.5,
       "tempo_bpm": 150,
       "era_year": 2017,
-      "language": "en",
-      "instrumentation": ["808", "synth", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        0,
+        13,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.8,
       "yt_views": 950000000,
-      "regionality": ["global", "us"]
+      "regionality": [
+        4,
+        8
+      ]
     },
-    "meta": {"duration_sec": 177, "loudness_lufs": -7.2}
+    "meta": {
+      "duration_sec": 177,
+      "loudness_lufs": -7.2
+    }
   },
   {
     "id": "song_006",
     "artist": "Miles Davis",
     "title": "So What",
     "youtube_url": "https://www.youtube.com/watch?v=zqNTltOGh5c",
-    "clip": {"start_sec": 60, "preview_sec": 30},
-    "genres": [5, 50],
+    "clip": {
+      "start_sec": 60,
+      "preview_sec": 30
+    },
+    "genres": [
+      5,
+      50
+    ],
     "tags": {
-      "subgenres": ["modal_jazz", "cool_jazz"],
-      "mood": ["sophisticated", "relaxed", "contemplative"],
+      "subgenres": [
+        40,
+        10
+      ],
+      "mood": [
+        58,
+        52,
+        12
+      ],
       "energy": 0.4,
       "valence": 0.6,
       "tempo_bpm": 138,
       "era_year": 1959,
-      "language": "instrumental",
-      "instrumentation": ["trumpet", "saxophone", "piano", "bass", "drums"]
+      "language": 3,
+      "instrumentation": [
+        14,
+        11,
+        8,
+        1,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.65,
       "yt_views": 45000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 562, "loudness_lufs": -18.5}
+    "meta": {
+      "duration_sec": 562,
+      "loudness_lufs": -18.5
+    }
   },
   {
     "id": "song_007",
     "artist": "IU",
     "title": "Palette",
     "youtube_url": "https://www.youtube.com/watch?v=d9IxdwEFk1c",
-    "clip": {"start_sec": 50, "preview_sec": 30},
-    "genres": [2, 21],
+    "clip": {
+      "start_sec": 50,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      21
+    ],
     "tags": {
-      "subgenres": ["k_indie", "pop_ballad"],
-      "mood": ["nostalgic", "reflective", "warm"],
+      "subgenres": [
+        35,
+        44
+      ],
+      "mood": [
+        44,
+        51,
+        65
+      ],
       "energy": 0.5,
       "valence": 0.7,
       "tempo_bpm": 96,
       "era_year": 2017,
-      "language": "ko",
-      "instrumentation": ["guitar", "piano", "vocals"]
+      "language": 4,
+      "instrumentation": [
+        4,
+        8,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.9,
       "yt_views": 185000000,
-      "regionality": ["kr", "asia"]
+      "regionality": [
+        6,
+        0
+      ]
     },
-    "meta": {"duration_sec": 217, "loudness_lufs": -9.8}
+    "meta": {
+      "duration_sec": 217,
+      "loudness_lufs": -9.8
+    }
   },
   {
     "id": "song_008",
     "artist": "Nirvana",
     "title": "Smells Like Teen Spirit",
     "youtube_url": "https://www.youtube.com/watch?v=hTWKbfoikeg",
-    "clip": {"start_sec": 24, "preview_sec": 30},
-    "genres": [1, 12],
+    "clip": {
+      "start_sec": 24,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      12
+    ],
     "tags": {
-      "subgenres": ["grunge", "alternative_rock"],
-      "mood": ["rebellious", "angst", "raw"],
+      "subgenres": [
+        27,
+        3
+      ],
+      "mood": [
+        50,
+        2,
+        49
+      ],
       "energy": 0.95,
       "valence": 0.4,
       "tempo_bpm": 117,
       "era_year": 1991,
-      "language": "en",
-      "instrumentation": ["guitar", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        4,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.93,
       "yt_views": 1400000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 301, "loudness_lufs": -9.2}
+    "meta": {
+      "duration_sec": 301,
+      "loudness_lufs": -9.2
+    }
   },
   {
     "id": "song_009",
     "artist": "Blackpink",
     "title": "DDU-DU DDU-DU",
     "youtube_url": "https://www.youtube.com/watch?v=IHNzOHi8sJs",
-    "clip": {"start_sec": 60, "preview_sec": 30},
-    "genres": [2, 20],
+    "clip": {
+      "start_sec": 60,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      20
+    ],
     "tags": {
-      "subgenres": ["kpop", "edm_pop", "trap"],
-      "mood": ["fierce", "confident", "powerful"],
+      "subgenres": [
+        38,
+        15,
+        56
+      ],
+      "mood": [
+        27,
+        11,
+        48
+      ],
       "energy": 0.92,
       "valence": 0.65,
       "tempo_bpm": 145,
       "era_year": 2018,
-      "language": "ko",
-      "instrumentation": ["synth", "808", "vocals"]
+      "language": 4,
+      "instrumentation": [
+        13,
+        0,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.91,
       "yt_views": 2000000000,
-      "regionality": ["global", "kr", "asia"]
+      "regionality": [
+        4,
+        6,
+        0
+      ]
     },
-    "meta": {"duration_sec": 209, "loudness_lufs": -5.8}
+    "meta": {
+      "duration_sec": 209,
+      "loudness_lufs": -5.8
+    }
   },
   {
     "id": "song_010",
     "artist": "The Weeknd",
     "title": "Blinding Lights",
     "youtube_url": "https://www.youtube.com/watch?v=4NRXx6U8ABQ",
-    "clip": {"start_sec": 35, "preview_sec": 30},
-    "genres": [2, 23],
+    "clip": {
+      "start_sec": 35,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      23
+    ],
     "tags": {
-      "subgenres": ["synthwave", "synth_pop"],
-      "mood": ["nostalgic", "euphoric", "driving"],
+      "subgenres": [
+        55,
+        54
+      ],
+      "mood": [
+        44,
+        26,
+        18
+      ],
       "energy": 0.88,
       "valence": 0.75,
       "tempo_bpm": 171,
       "era_year": 2019,
-      "language": "en",
-      "instrumentation": ["synth", "drums", "bass", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        2,
+        1,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.96,
       "yt_views": 1100000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 200, "loudness_lufs": -7.1}
+    "meta": {
+      "duration_sec": 200,
+      "loudness_lufs": -7.1
+    }
   },
   {
     "id": "song_011",
     "artist": "Aphex Twin",
     "title": "Windowlicker",
     "youtube_url": "https://www.youtube.com/watch?v=UBS4Gi1y_nc",
-    "clip": {"start_sec": 180, "preview_sec": 30},
-    "genres": [3, 32],
+    "clip": {
+      "start_sec": 180,
+      "preview_sec": 30
+    },
+    "genres": [
+      3,
+      32
+    ],
     "tags": {
-      "subgenres": ["idm", "experimental_electronic"],
-      "mood": ["surreal", "complex", "unsettling"],
+      "subgenres": [
+        30,
+        21
+      ],
+      "mood": [
+        60,
+        10,
+        62
+      ],
       "energy": 0.7,
       "valence": 0.5,
       "tempo_bpm": 132,
       "era_year": 1999,
-      "language": "en",
-      "instrumentation": ["synth", "drums", "vocoder"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        2,
+        16
+      ]
     },
     "popularity": {
       "awareness_idx": 0.45,
       "yt_views": 28000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 375, "loudness_lufs": -10.2}
+    "meta": {
+      "duration_sec": 375,
+      "loudness_lufs": -10.2
+    }
   },
   {
     "id": "song_012",
     "artist": "Billie Eilish",
     "title": "bad guy",
     "youtube_url": "https://www.youtube.com/watch?v=DyDfgMOUjCI",
-    "clip": {"start_sec": 20, "preview_sec": 30},
-    "genres": [2, 24],
+    "clip": {
+      "start_sec": 20,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      24
+    ],
     "tags": {
-      "subgenres": ["alt_pop", "electropop"],
-      "mood": ["dark", "playful", "minimalist"],
+      "subgenres": [
+        0,
+        19
+      ],
+      "mood": [
+        14,
+        47,
+        39
+      ],
       "energy": 0.65,
       "valence": 0.55,
       "tempo_bpm": 135,
       "era_year": 2019,
-      "language": "en",
-      "instrumentation": ["bass", "synth", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        1,
+        13,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.94,
       "yt_views": 1300000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 194, "loudness_lufs": -11.3}
+    "meta": {
+      "duration_sec": 194,
+      "loudness_lufs": -11.3
+    }
   },
   {
     "id": "song_013",
     "artist": "Chopin",
     "title": "Nocturne Op.9 No.2",
     "youtube_url": "https://www.youtube.com/watch?v=9E6b3swbnWg",
-    "clip": {"start_sec": 60, "preview_sec": 30},
-    "genres": [6, 60],
+    "clip": {
+      "start_sec": 60,
+      "preview_sec": 30
+    },
+    "genres": [
+      6,
+      60
+    ],
     "tags": {
-      "subgenres": ["romantic_classical", "piano_solo"],
-      "mood": ["serene", "romantic", "elegant"],
+      "subgenres": [
+        52,
+        43
+      ],
+      "mood": [
+        56,
+        53,
+        20
+      ],
       "energy": 0.3,
       "valence": 0.7,
       "tempo_bpm": 58,
       "era_year": 1832,
-      "language": "instrumental",
-      "instrumentation": ["piano"]
+      "language": 3,
+      "instrumentation": [
+        8
+      ]
     },
     "popularity": {
       "awareness_idx": 0.75,
       "yt_views": 95000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 276, "loudness_lufs": -20.5}
+    "meta": {
+      "duration_sec": 276,
+      "loudness_lufs": -20.5
+    }
   },
   {
     "id": "song_014",
     "artist": "Tame Impala",
     "title": "The Less I Know The Better",
     "youtube_url": "https://www.youtube.com/watch?v=sBzrzS1Ag_g",
-    "clip": {"start_sec": 50, "preview_sec": 30},
-    "genres": [1, 13],
+    "clip": {
+      "start_sec": 50,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      13
+    ],
     "tags": {
-      "subgenres": ["psychedelic_rock", "indie_rock"],
-      "mood": ["groovy", "dreamy", "melancholic"],
+      "subgenres": [
+        48,
+        32
+      ],
+      "mood": [
+        29,
+        17,
+        37
+      ],
       "energy": 0.75,
       "valence": 0.6,
       "tempo_bpm": 116,
       "era_year": 2015,
-      "language": "en",
-      "instrumentation": ["synth", "bass", "guitar", "drums"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        1,
+        4,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.72,
       "yt_views": 520000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 216, "loudness_lufs": -9.5}
+    "meta": {
+      "duration_sec": 216,
+      "loudness_lufs": -9.5
+    }
   },
   {
     "id": "song_015",
     "artist": "Epik High",
     "title": "Born Hater",
     "youtube_url": "https://www.youtube.com/watch?v=3s1jaFDrp5M",
-    "clip": {"start_sec": 70, "preview_sec": 30},
-    "genres": [4, 41],
+    "clip": {
+      "start_sec": 70,
+      "preview_sec": 30
+    },
+    "genres": [
+      4,
+      41
+    ],
     "tags": {
-      "subgenres": ["korean_hip_hop", "alternative_hip_hop"],
-      "mood": ["defiant", "intense", "dark"],
+      "subgenres": [
+        37,
+        1
+      ],
+      "mood": [
+        15,
+        32,
+        14
+      ],
       "energy": 0.8,
       "valence": 0.45,
       "tempo_bpm": 88,
       "era_year": 2014,
-      "language": "ko",
-      "instrumentation": ["bass", "drums", "synth", "vocals"]
+      "language": 4,
+      "instrumentation": [
+        1,
+        2,
+        13,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.68,
       "yt_views": 52000000,
-      "regionality": ["kr", "asia"]
+      "regionality": [
+        6,
+        0
+      ]
     },
-    "meta": {"duration_sec": 272, "loudness_lufs": -8.2}
+    "meta": {
+      "duration_sec": 272,
+      "loudness_lufs": -8.2
+    }
   },
   {
     "id": "song_016",
     "artist": "Pink Floyd",
     "title": "Comfortably Numb",
     "youtube_url": "https://www.youtube.com/watch?v=_FrOQC-zEog",
-    "clip": {"start_sec": 200, "preview_sec": 30},
-    "genres": [1, 11],
+    "clip": {
+      "start_sec": 200,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      11
+    ],
     "tags": {
-      "subgenres": ["progressive_rock", "psychedelic_rock"],
-      "mood": ["introspective", "ethereal", "epic"],
+      "subgenres": [
+        46,
+        48
+      ],
+      "mood": [
+        34,
+        25,
+        24
+      ],
       "energy": 0.65,
       "valence": 0.5,
       "tempo_bpm": 63,
       "era_year": 1979,
-      "language": "en",
-      "instrumentation": ["guitar", "synth", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        4,
+        13,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.87,
       "yt_views": 280000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 382, "loudness_lufs": -13.8}
+    "meta": {
+      "duration_sec": 382,
+      "loudness_lufs": -13.8
+    }
   },
   {
     "id": "song_017",
     "artist": "Porter Robinson",
     "title": "Shelter",
     "youtube_url": "https://www.youtube.com/watch?v=fzQ6gRAEoy0",
-    "clip": {"start_sec": 45, "preview_sec": 30},
-    "genres": [3, 33],
+    "clip": {
+      "start_sec": 45,
+      "preview_sec": 30
+    },
+    "genres": [
+      3,
+      33
+    ],
     "tags": {
-      "subgenres": ["future_bass", "electronic"],
-      "mood": ["emotional", "uplifting", "nostalgic"],
+      "subgenres": [
+        26,
+        17
+      ],
+      "mood": [
+        21,
+        64,
+        44
+      ],
       "energy": 0.8,
       "valence": 0.75,
       "tempo_bpm": 128,
       "era_year": 2016,
-      "language": "en",
-      "instrumentation": ["synth", "vocals", "drums"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        15,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.55,
       "yt_views": 95000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 215, "loudness_lufs": -7.8}
+    "meta": {
+      "duration_sec": 215,
+      "loudness_lufs": -7.8
+    }
   },
   {
     "id": "song_018",
     "artist": "Ariana Grande",
     "title": "7 rings",
     "youtube_url": "https://www.youtube.com/watch?v=QYh6mYIJG2Y",
-    "clip": {"start_sec": 30, "preview_sec": 30},
-    "genres": [2, 22],
+    "clip": {
+      "start_sec": 30,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      22
+    ],
     "tags": {
-      "subgenres": ["trap_pop", "r&b"],
-      "mood": ["confident", "luxurious", "bold"],
+      "subgenres": [
+        57,
+        49
+      ],
+      "mood": [
+        11,
+        36,
+        5
+      ],
       "energy": 0.78,
       "valence": 0.65,
       "tempo_bpm": 138,
       "era_year": 2008,
-      "language": "en",
-      "instrumentation": ["strings", "piano", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        12,
+        8,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.94,
       "yt_views": 1200000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 242, "loudness_lufs": -8.8}
+    "meta": {
+      "duration_sec": 242,
+      "loudness_lufs": -8.8
+    }
   },
   {
     "id": "song_030",
     "artist": "Massive Attack",
     "title": "Teardrop",
     "youtube_url": "https://www.youtube.com/watch?v=u7K72X4eo_s",
-    "clip": {"start_sec": 60, "preview_sec": 30},
-    "genres": [3, 34],
+    "clip": {
+      "start_sec": 60,
+      "preview_sec": 30
+    },
+    "genres": [
+      3,
+      34
+    ],
     "tags": {
-      "subgenres": ["trip_hop", "downtempo"],
-      "mood": ["haunting", "atmospheric", "melancholic"],
+      "subgenres": [
+        58,
+        14
+      ],
+      "mood": [
+        30,
+        3,
+        37
+      ],
       "energy": 0.4,
       "valence": 0.35,
       "tempo_bpm": 80,
       "era_year": 1998,
-      "language": "en",
-      "instrumentation": ["synth", "guitar", "vocals", "drums"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        4,
+        15,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.68,
       "yt_views": 125000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 329, "loudness_lufs": -12.5}
+    "meta": {
+      "duration_sec": 329,
+      "loudness_lufs": -12.5
+    }
   },
   {
     "id": "song_031",
     "artist": "Rosalía",
     "title": "Malamente",
     "youtube_url": "https://www.youtube.com/watch?v=Rht7rBHuXW8",
-    "clip": {"start_sec": 40, "preview_sec": 30},
-    "genres": [2, 28],
+    "clip": {
+      "start_sec": 40,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      28
+    ],
     "tags": {
-      "subgenres": ["flamenco_pop", "experimental_pop"],
-      "mood": ["intense", "passionate", "avant_garde"],
+      "subgenres": [
+        23,
+        22
+      ],
+      "mood": [
+        32,
+        45,
+        4
+      ],
       "energy": 0.85,
       "valence": 0.6,
       "tempo_bpm": 162,
       "era_year": 2018,
-      "language": "es",
-      "instrumentation": ["palmas", "vocals", "electronic_beats"]
+      "language": 1,
+      "instrumentation": [
+        6,
+        15,
+        3
+      ]
     },
     "popularity": {
       "awareness_idx": 0.62,
       "yt_views": 180000000,
-      "regionality": ["es", "latam", "global"]
+      "regionality": [
+        1,
+        7,
+        4
+      ]
     },
-    "meta": {"duration_sec": 163, "loudness_lufs": -7.5}
+    "meta": {
+      "duration_sec": 163,
+      "loudness_lufs": -7.5
+    }
   },
   {
     "id": "song_032",
     "artist": "Frank Ocean",
     "title": "Nights",
     "youtube_url": "https://www.youtube.com/watch?v=r4l9bFqgMaQ",
-    "clip": {"start_sec": 180, "preview_sec": 30},
-    "genres": [2, 26],
+    "clip": {
+      "start_sec": 180,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      26
+    ],
     "tags": {
-      "subgenres": ["alternative_r&b", "experimental"],
-      "mood": ["introspective", "dynamic", "nocturnal"],
+      "subgenres": [
+        2,
+        20
+      ],
+      "mood": [
+        34,
+        19,
+        43
+      ],
       "energy": 0.75,
       "valence": 0.55,
       "tempo_bpm": 127,
       "era_year": 2016,
-      "language": "en",
-      "instrumentation": ["synth", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.77,
       "yt_views": 92000000,
-      "regionality": ["global", "us"]
+      "regionality": [
+        4,
+        8
+      ]
     },
-    "meta": {"duration_sec": 307, "loudness_lufs": -9.2}
+    "meta": {
+      "duration_sec": 307,
+      "loudness_lufs": -9.2
+    }
   },
   {
     "id": "song_033",
     "artist": "DEAN",
     "title": "Instagram",
     "youtube_url": "https://www.youtube.com/watch?v=wKyMIrBClYw",
-    "clip": {"start_sec": 50, "preview_sec": 30},
-    "genres": [2, 26],
+    "clip": {
+      "start_sec": 50,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      26
+    ],
     "tags": {
-      "subgenres": ["k_r&b", "alternative_r&b"],
-      "mood": ["smooth", "confident", "modern"],
+      "subgenres": [
+        36,
+        2
+      ],
+      "mood": [
+        57,
+        11,
+        40
+      ],
       "energy": 0.68,
       "valence": 0.7,
       "tempo_bpm": 95,
       "era_year": 2016,
-      "language": "ko",
-      "instrumentation": ["synth", "bass", "drums", "vocals"]
+      "language": 4,
+      "instrumentation": [
+        13,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.71,
       "yt_views": 68000000,
-      "regionality": ["kr", "asia"]
+      "regionality": [
+        6,
+        0
+      ]
     },
-    "meta": {"duration_sec": 185, "loudness_lufs": -8.9}
+    "meta": {
+      "duration_sec": 185,
+      "loudness_lufs": -8.9
+    }
   },
   {
     "id": "song_034",
     "artist": "Fleetwood Mac",
     "title": "Dreams",
     "youtube_url": "https://www.youtube.com/watch?v=mrZRURcb1cM",
-    "clip": {"start_sec": 30, "preview_sec": 30},
-    "genres": [1, 19],
+    "clip": {
+      "start_sec": 30,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      19
+    ],
     "tags": {
-      "subgenres": ["soft_rock", "pop_rock"],
-      "mood": ["dreamy", "nostalgic", "smooth"],
+      "subgenres": [
+        53,
+        45
+      ],
+      "mood": [
+        17,
+        44,
+        57
+      ],
       "energy": 0.55,
       "valence": 0.6,
       "tempo_bpm": 119,
       "era_year": 1977,
-      "language": "en",
-      "instrumentation": ["guitar", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        4,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.89,
       "yt_views": 380000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 257, "loudness_lufs": -13.2}
+    "meta": {
+      "duration_sec": 257,
+      "loudness_lufs": -13.2
+    }
   },
   {
     "id": "song_035",
     "artist": "Boards of Canada",
     "title": "Roygbiv",
     "youtube_url": "https://www.youtube.com/watch?v=yT0gRc2c2wQ",
-    "clip": {"start_sec": 40, "preview_sec": 30},
-    "genres": [3, 35],
+    "clip": {
+      "start_sec": 40,
+      "preview_sec": 30
+    },
+    "genres": [
+      3,
+      35
+    ],
     "tags": {
-      "subgenres": ["idm", "ambient", "electronica"],
-      "mood": ["nostalgic", "peaceful", "abstract"],
+      "subgenres": [
+        30,
+        4,
+        18
+      ],
+      "mood": [
+        44,
+        46,
+        0
+      ],
       "energy": 0.45,
       "valence": 0.65,
       "tempo_bpm": 128,
       "era_year": 1998,
-      "language": "instrumental",
-      "instrumentation": ["synth", "samples"]
+      "language": 3,
+      "instrumentation": [
+        13,
+        10
+      ]
     },
     "popularity": {
       "awareness_idx": 0.42,
       "yt_views": 15000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 141, "loudness_lufs": -14.8}
+    "meta": {
+      "duration_sec": 141,
+      "loudness_lufs": -14.8
+    }
   },
   {
     "id": "song_036",
     "artist": "Red Velvet",
     "title": "Psycho",
     "youtube_url": "https://www.youtube.com/watch?v=uR8Mrt1IpXg",
-    "clip": {"start_sec": 55, "preview_sec": 30},
-    "genres": [2, 20],
+    "clip": {
+      "start_sec": 55,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      20
+    ],
     "tags": {
-      "subgenres": ["kpop", "r&b_pop"],
-      "mood": ["seductive", "dark", "complex"],
+      "subgenres": [
+        38,
+        50
+      ],
+      "mood": [
+        55,
+        14,
+        10
+      ],
       "energy": 0.72,
       "valence": 0.58,
       "tempo_bpm": 140,
       "era_year": 2019,
-      "language": "ko",
-      "instrumentation": ["synth", "bass", "vocals"]
+      "language": 4,
+      "instrumentation": [
+        13,
+        1,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.85,
       "yt_views": 450000000,
-      "regionality": ["kr", "asia", "global"]
+      "regionality": [
+        6,
+        0,
+        4
+      ]
     },
-    "meta": {"duration_sec": 210, "loudness_lufs": -7.8}
+    "meta": {
+      "duration_sec": 210,
+      "loudness_lufs": -7.8
+    }
   },
   {
     "id": "song_037",
     "artist": "Led Zeppelin",
     "title": "Stairway to Heaven",
     "youtube_url": "https://www.youtube.com/watch?v=QkF3oxziUI4",
-    "clip": {"start_sec": 240, "preview_sec": 30},
-    "genres": [1, 10],
+    "clip": {
+      "start_sec": 240,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      10
+    ],
     "tags": {
-      "subgenres": ["hard_rock", "progressive_rock"],
-      "mood": ["epic", "mystical", "building"],
+      "subgenres": [
+        28,
+        46
+      ],
+      "mood": [
+        24,
+        42,
+        7
+      ],
       "energy": 0.85,
       "valence": 0.6,
       "tempo_bpm": 82,
       "era_year": 1971,
-      "language": "en",
-      "instrumentation": ["guitar", "drums", "bass", "vocals", "recorder"]
+      "language": 0,
+      "instrumentation": [
+        4,
+        2,
+        1,
+        15,
+        9
+      ]
     },
     "popularity": {
       "awareness_idx": 0.93,
       "yt_views": 320000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 482, "loudness_lufs": -12.5}
+    "meta": {
+      "duration_sec": 482,
+      "loudness_lufs": -12.5
+    }
   },
   {
     "id": "song_038",
     "artist": "SZA",
     "title": "Good Days",
     "youtube_url": "https://www.youtube.com/watch?v=LILRp6kWFV8",
-    "clip": {"start_sec": 60, "preview_sec": 30},
-    "genres": [2, 26],
+    "clip": {
+      "start_sec": 60,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      26
+    ],
     "tags": {
-      "subgenres": ["neo_soul", "r&b"],
-      "mood": ["hopeful", "reflective", "peaceful"],
+      "subgenres": [
+        41,
+        49
+      ],
+      "mood": [
+        31,
+        51,
+        46
+      ],
       "energy": 0.5,
       "valence": 0.7,
       "tempo_bpm": 121,
       "era_year": 2020,
-      "language": "en",
-      "instrumentation": ["guitar", "synth", "vocals", "drums"]
+      "language": 0,
+      "instrumentation": [
+        4,
+        13,
+        15,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.78,
       "yt_views": 185000000,
-      "regionality": ["global", "us"]
+      "regionality": [
+        4,
+        8
+      ]
     },
-    "meta": {"duration_sec": 279, "loudness_lufs": -9.5}
+    "meta": {
+      "duration_sec": 279,
+      "loudness_lufs": -9.5
+    }
   },
   {
     "id": "song_039",
     "artist": "The Beatles",
     "title": "Come Together",
     "youtube_url": "https://www.youtube.com/watch?v=45cYwDMibGo",
-    "clip": {"start_sec": 30, "preview_sec": 30},
-    "genres": [1, 19],
+    "clip": {
+      "start_sec": 30,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      19
+    ],
     "tags": {
-      "subgenres": ["rock", "blues_rock"],
-      "mood": ["groovy", "mysterious", "funky"],
+      "subgenres": [
+        51,
+        6
+      ],
+      "mood": [
+        29,
+        41,
+        28
+      ],
       "energy": 0.7,
       "valence": 0.65,
       "tempo_bpm": 83,
       "era_year": 1969,
-      "language": "en",
-      "instrumentation": ["bass", "guitar", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        1,
+        4,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.95,
       "yt_views": 290000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 259, "loudness_lufs": -14.2}
+    "meta": {
+      "duration_sec": 259,
+      "loudness_lufs": -14.2
+    }
   },
   {
     "id": "song_040",
     "artist": "BadBadNotGood",
     "title": "Time Moves Slow",
     "youtube_url": "https://www.youtube.com/watch?v=UWIIPX_5rbM",
-    "clip": {"start_sec": 70, "preview_sec": 30},
-    "genres": [5, 51],
+    "clip": {
+      "start_sec": 70,
+      "preview_sec": 30
+    },
+    "genres": [
+      5,
+      51
+    ],
     "tags": {
-      "subgenres": ["contemporary_jazz", "neo_soul"],
-      "mood": ["smooth", "contemplative", "mellow"],
+      "subgenres": [
+        9,
+        41
+      ],
+      "mood": [
+        57,
+        12,
+        38
+      ],
       "energy": 0.45,
       "valence": 0.6,
       "tempo_bpm": 74,
       "era_year": 2016,
-      "language": "en",
-      "instrumentation": ["saxophone", "keyboards", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        11,
+        5,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.38,
       "yt_views": 28000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 303, "loudness_lufs": -11.8}
+    "meta": {
+      "duration_sec": 303,
+      "loudness_lufs": -11.8
+    }
   },
   {
     "id": "song_041",
     "artist": "TWICE",
     "title": "Feel Special",
     "youtube_url": "https://www.youtube.com/watch?v=3ymwOvzhwHs",
-    "clip": {"start_sec": 65, "preview_sec": 30},
-    "genres": [2, 20],
+    "clip": {
+      "start_sec": 65,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      20
+    ],
     "tags": {
-      "subgenres": ["kpop", "dance_pop"],
-      "mood": ["empowering", "uplifting", "bright"],
+      "subgenres": [
+        38,
+        12
+      ],
+      "mood": [
+        22,
+        64,
+        6
+      ],
       "energy": 0.85,
       "valence": 0.8,
       "tempo_bpm": 128,
       "era_year": 2019,
-      "language": "ko",
-      "instrumentation": ["synth", "bass", "vocals", "drums"]
+      "language": 4,
+      "instrumentation": [
+        13,
+        1,
+        15,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.88,
       "yt_views": 520000000,
-      "regionality": ["kr", "asia", "global"]
+      "regionality": [
+        6,
+        0,
+        4
+      ]
     },
-    "meta": {"duration_sec": 206, "loudness_lufs": -6.8}
+    "meta": {
+      "duration_sec": 206,
+      "loudness_lufs": -6.8
+    }
   },
   {
     "id": "song_042",
     "artist": "J Dilla",
     "title": "Don't Cry",
     "youtube_url": "https://www.youtube.com/watch?v=tVkOw-Vyb_U",
-    "clip": {"start_sec": 20, "preview_sec": 30},
-    "genres": [4, 45],
+    "clip": {
+      "start_sec": 20,
+      "preview_sec": 30
+    },
+    "genres": [
+      4,
+      45
+    ],
     "tags": {
-      "subgenres": ["instrumental_hip_hop", "lo_fi"],
-      "mood": ["nostalgic", "melancholic", "soulful"],
+      "subgenres": [
+        33,
+        39
+      ],
+      "mood": [
+        44,
+        37,
+        59
+      ],
       "energy": 0.4,
       "valence": 0.45,
       "tempo_bpm": 88,
       "era_year": 2006,
-      "language": "instrumental",
-      "instrumentation": ["samples", "drums", "bass"]
+      "language": 3,
+      "instrumentation": [
+        10,
+        2,
+        1
+      ]
     },
     "popularity": {
       "awareness_idx": 0.52,
       "yt_views": 18000000,
-      "regionality": ["global", "us"]
+      "regionality": [
+        4,
+        8
+      ]
     },
-    "meta": {"duration_sec": 153, "loudness_lufs": -13.5}
+    "meta": {
+      "duration_sec": 153,
+      "loudness_lufs": -13.5
+    }
   },
   {
     "id": "song_043",
     "artist": "Björk",
     "title": "Hyperballad",
     "youtube_url": "https://www.youtube.com/watch?v=26sP2WsA5cY",
-    "clip": {"start_sec": 50, "preview_sec": 30},
-    "genres": [2, 27],
+    "clip": {
+      "start_sec": 50,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      27
+    ],
     "tags": {
-      "subgenres": ["art_pop", "electronic", "experimental"],
-      "mood": ["ethereal", "whimsical", "intense"],
+      "subgenres": [
+        5,
+        17,
+        20
+      ],
+      "mood": [
+        25,
+        66,
+        32
+      ],
       "energy": 0.75,
       "valence": 0.65,
       "tempo_bpm": 121,
       "era_year": 1995,
-      "language": "en",
-      "instrumentation": ["synth", "strings", "vocals", "drums"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        12,
+        15,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.58,
       "yt_views": 25000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 317, "loudness_lufs": -10.8}
+    "meta": {
+      "duration_sec": 317,
+      "loudness_lufs": -10.8
+    }
   },
   {
     "id": "song_044",
     "artist": "Anderson .Paak",
     "title": "Come Down",
     "youtube_url": "https://www.youtube.com/watch?v=ferZnZ0_rSM",
-    "clip": {"start_sec": 35, "preview_sec": 30},
-    "genres": [4, 46],
+    "clip": {
+      "start_sec": 35,
+      "preview_sec": 30
+    },
+    "genres": [
+      4,
+      46
+    ],
     "tags": {
-      "subgenres": ["neo_soul", "funk", "hip_hop"],
-      "mood": ["groovy", "energetic", "playful"],
+      "subgenres": [
+        41,
+        25,
+        29
+      ],
+      "mood": [
+        29,
+        23,
+        47
+      ],
       "energy": 0.82,
       "valence": 0.75,
       "tempo_bpm": 103,
       "era_year": 2016,
-      "language": "en",
-      "instrumentation": ["drums", "bass", "synth", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        2,
+        1,
+        13,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.64,
       "yt_views": 65000000,
-      "regionality": ["global", "us"]
+      "regionality": [
+        4,
+        8
+      ]
     },
-    "meta": {"duration_sec": 248, "loudness_lufs": -8.8}
+    "meta": {
+      "duration_sec": 248,
+      "loudness_lufs": -8.8
+    }
   },
   {
     "id": "song_045",
     "artist": "Nujabes",
     "title": "Feather",
     "youtube_url": "https://www.youtube.com/watch?v=jfFTT3iz740",
-    "clip": {"start_sec": 40, "preview_sec": 30},
-    "genres": [4, 45],
+    "clip": {
+      "start_sec": 40,
+      "preview_sec": 30
+    },
+    "genres": [
+      4,
+      45
+    ],
     "tags": {
-      "subgenres": ["jazz_hop", "chillhop"],
-      "mood": ["peaceful", "uplifting", "contemplative"],
+      "subgenres": [
+        34,
+        8
+      ],
+      "mood": [
+        46,
+        64,
+        12
+      ],
       "energy": 0.5,
       "valence": 0.7,
       "tempo_bpm": 90,
       "era_year": 2005,
-      "language": "en",
-      "instrumentation": ["piano", "bass", "drums", "vocals"]
+      "language": 0,
+      "instrumentation": [
+        8,
+        1,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.56,
       "yt_views": 82000000,
-      "regionality": ["global", "jp"]
+      "regionality": [
+        4,
+        5
+      ]
     },
-    "meta": {"duration_sec": 175, "loudness_lufs": -12.2}
+    "meta": {
+      "duration_sec": 175,
+      "loudness_lufs": -12.2
+    }
   },
   {
     "id": "song_046",
     "artist": "MGMT",
     "title": "Electric Feel",
     "youtube_url": "https://www.youtube.com/watch?v=MmZexg8sxyk",
-    "clip": {"start_sec": 45, "preview_sec": 30},
-    "genres": [1, 13],
+    "clip": {
+      "start_sec": 45,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      13
+    ],
     "tags": {
-      "subgenres": ["psychedelic_pop", "indie_rock"],
-      "mood": ["groovy", "trippy", "playful"],
+      "subgenres": [
+        47,
+        32
+      ],
+      "mood": [
+        29,
+        61,
+        47
+      ],
       "energy": 0.78,
       "valence": 0.75,
       "tempo_bpm": 106,
       "era_year": 2007,
-      "language": "en",
-      "instrumentation": ["synth", "guitar", "bass", "drums"]
+      "language": 0,
+      "instrumentation": [
+        13,
+        4,
+        1,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.76,
       "yt_views": 180000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 229, "loudness_lufs": -9.5}
+    "meta": {
+      "duration_sec": 229,
+      "loudness_lufs": -9.5
+    }
   },
   {
     "id": "song_047",
     "artist": "NewJeans",
     "title": "Ditto",
     "youtube_url": "https://www.youtube.com/watch?v=Rrf8uQFvICE",
-    "clip": {"start_sec": 40, "preview_sec": 30},
-    "genres": [2, 20],
+    "clip": {
+      "start_sec": 40,
+      "preview_sec": 30
+    },
+    "genres": [
+      2,
+      20
+    ],
     "tags": {
-      "subgenres": ["kpop", "uk_garage"],
-      "mood": ["nostalgic", "youthful", "dreamy"],
+      "subgenres": [
+        38,
+        59
+      ],
+      "mood": [
+        44,
+        67,
+        17
+      ],
       "energy": 0.68,
       "valence": 0.72,
       "tempo_bpm": 126,
       "era_year": 2022,
-      "language": "ko",
-      "instrumentation": ["synth", "bass", "vocals", "percussion"]
+      "language": 4,
+      "instrumentation": [
+        13,
+        1,
+        15,
+        7
+      ]
     },
     "popularity": {
       "awareness_idx": 0.87,
       "yt_views": 320000000,
-      "regionality": ["kr", "asia", "global"]
+      "regionality": [
+        6,
+        0,
+        4
+      ]
     },
-    "meta": {"duration_sec": 186, "loudness_lufs": -7.5}
+    "meta": {
+      "duration_sec": 186,
+      "loudness_lufs": -7.5
+    }
   },
   {
     "id": "song_048",
     "artist": "Gorillaz",
     "title": "Feel Good Inc.",
     "youtube_url": "https://www.youtube.com/watch?v=HyHNuVaZJ-k",
-    "clip": {"start_sec": 50, "preview_sec": 30},
-    "genres": [1, 14],
+    "clip": {
+      "start_sec": 50,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      14
+    ],
     "tags": {
-      "subgenres": ["alternative_rock", "hip_hop", "electronic"],
-      "mood": ["dark", "groovy", "satirical"],
+      "subgenres": [
+        3,
+        29,
+        17
+      ],
+      "mood": [
+        14,
+        29,
+        54
+      ],
       "energy": 0.8,
       "valence": 0.55,
       "tempo_bpm": 138,
       "era_year": 2005,
-      "language": "en",
-      "instrumentation": ["bass", "synth", "vocals", "drums"]
+      "language": 0,
+      "instrumentation": [
+        1,
+        13,
+        15,
+        2
+      ]
     },
     "popularity": {
       "awareness_idx": 0.89,
       "yt_views": 740000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 222, "loudness_lufs": -8.2}
+    "meta": {
+      "duration_sec": 222,
+      "loudness_lufs": -8.2
+    }
   },
   {
     "id": "song_049",
     "artist": "Bon Iver",
     "title": "Holocene",
     "youtube_url": "https://www.youtube.com/watch?v=TWcyIpul8OE",
-    "clip": {"start_sec": 80, "preview_sec": 30},
-    "genres": [1, 17],
+    "clip": {
+      "start_sec": 80,
+      "preview_sec": 30
+    },
+    "genres": [
+      1,
+      17
+    ],
     "tags": {
-      "subgenres": ["indie_folk", "chamber_pop"],
-      "mood": ["contemplative", "ethereal", "intimate"],
+      "subgenres": [
+        31,
+        7
+      ],
+      "mood": [
+        12,
+        25,
+        33
+      ],
       "energy": 0.4,
       "valence": 0.5,
       "tempo_bpm": 76,
       "era_year": 2011,
-      "language": "en",
-      "instrumentation": ["guitar", "piano", "vocals", "strings"]
+      "language": 0,
+      "instrumentation": [
+        4,
+        8,
+        15,
+        12
+      ]
     },
     "popularity": {
       "awareness_idx": 0.62,
       "yt_views": 52000000,
-      "regionality": ["global"]
+      "regionality": [
+        4
+      ]
     },
-    "meta": {"duration_sec": 336, "loudness_lufs": -13.8}
+    "meta": {
+      "duration_sec": 336,
+      "loudness_lufs": -13.8
+    }
   },
   {
     "id": "song_050",
     "artist": "Stromae",
     "title": "Alors on danse",
     "youtube_url": "https://www.youtube.com/watch?v=VHoT4N43jK8",
-    "clip": {"start_sec": 35, "preview_sec": 30},
-    "genres": [3, 36],
+    "clip": {
+      "start_sec": 35,
+      "preview_sec": 30
+    },
+    "genres": [
+      3,
+      36
+    ],
     "tags": {
-      "subgenres": ["electro_house", "hip_hop"],
-      "mood": ["melancholic", "danceable", "ironic"],
+      "subgenres": [
+        16,
+        29
+      ],
+      "mood": [
+        37,
+        13,
+        35
+      ],
       "energy": 0.85,
       "valence": 0.5,
       "tempo_bpm": 128,
       "era_year": 2009,
-      "language": "fr",
-      "instrumentation": ["synth", "drums", "vocals"]
+      "language": 2,
+      "instrumentation": [
+        13,
+        2,
+        15
+      ]
     },
     "popularity": {
       "awareness_idx": 0.74,
       "yt_views": 520000000,
-      "regionality": ["fr", "eu", "global"]
+      "regionality": [
+        3,
+        2,
+        4
+      ]
     },
-    "meta": {"duration_sec": 206, "loudness_lufs": -7.8}
+    "meta": {
+      "duration_sec": 206,
+      "loudness_lufs": -7.8
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- define canonical index tables for song subgenres, moods, languages, instrumentation, and regionality
- decode indexed metadata values when loading JSON song data
- convert `songs.json` to store the metadata fields as indices instead of raw strings

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d90cefc218832b880875485e0c3c51