### PR TITLE
Replace Tkinter GUI with PyQt6

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@
 import json
 import math
 import random
+import sys
 import webbrowser
 from pathlib import Path
 from typing import List, Dict, Tuple, Optional, Set, Any
@@ -14,8 +15,25 @@ from collections import defaultdict
 import numpy as np
 from sklearn.cluster import KMeans
 from datetime import datetime
-import tkinter as tk
-from tkinter import ttk, messagebox
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import (
+    QApplication,
+    QButtonGroup,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QProgressBar,
+    QRadioButton,
+    QScrollArea,
+    QStatusBar,
+    QVBoxLayout,
+    QWidget,
+)
 
 # ============================================================================
 # JSON 구조 & 인덱스 가이드
@@ -1294,142 +1312,108 @@ class MusicTournamentApp:
 # GUI 애플리케이션
 # ============================================================================
 
-class MusicTournamentGUI:
+
+
+class MusicTournamentGUI(QMainWindow):
     GENRE_PAIRS = [
         ("Rock", "Pop"),
         ("Hip-Hop", "Electronic"),
         ("Jazz", "Classical"),
-        ("K-Pop", "Indie")
+        ("K-Pop", "Indie"),
     ]
 
     ERA_OPTIONS = [
-        ("1970s-1980s", '1'),
-        ("1990s-2000s", '2'),
-        ("2010s 이후", '3'),
-        ("상관없음", '4')
+        ("1970s-1980s", "1"),
+        ("1990s-2000s", "2"),
+        ("2010s 이후", "3"),
+        ("상관없음", "4"),
     ]
 
     ENERGY_OPTIONS = [
-        ("차분한 무드", '1'),
-        ("보통 에너지", '2'),
-        ("활기찬 느낌", '3'),
-        ("강렬한 사운드", '4')
+        ("차분한 무드", "1"),
+        ("보통 에너지", "2"),
+        ("활기찬 느낌", "3"),
+        ("강렬한 사운드", "4"),
     ]
 
     POPULARITY_OPTIONS = [
-        ("유명한 히트곡", '1'),
-        ("적당히 알려진 곡", '2'),
-        ("숨은 명곡", '3')
+        ("유명한 히트곡", "1"),
+        ("적당히 알려진 곡", "2"),
+        ("숨은 명곡", "3"),
     ]
 
     LANGUAGE_OPTIONS = [
-        ("한국어", '1'),
-        ("영어", '2'),
-        ("기타 언어", '3'),
-        ("상관없음", '4')
+        ("한국어", "1"),
+        ("영어", "2"),
+        ("기타 언어", "3"),
+        ("상관없음", "4"),
     ]
 
     LANGUAGE_FOCUS_OPTIONS = [
-        ("거의 한국어만 들어요", '1'),
-        ("한국어/영어 위주", '2'),
-        ("영어/글로벌 위주", '3'),
-        ("다양한 언어 환영", '4')
+        ("거의 한국어만 들어요", "1"),
+        ("한국어/영어 위주", "2"),
+        ("영어/글로벌 위주", "3"),
+        ("다양한 언어 환영", "4"),
     ]
 
     REGIONAL_FOCUS_OPTIONS = [
-        ("한국 음악만 추천해주세요", '1'),
-        ("한국·아시아 중심", '2'),
-        ("글로벌 다양성", '3'),
-        ("잘 모르겠어요", '4')
+        ("한국 음악만 추천해주세요", "1"),
+        ("한국·아시아 중심", "2"),
+        ("글로벌 다양성", "3"),
+        ("잘 모르겠어요", "4"),
     ]
 
     def __init__(self, songs_file: str):
+        super().__init__()
         self.songs_file = songs_file
-        self.root = tk.Tk()
-        self.root.title("Whats My Music Flavor · 토너먼트 취향 테스트")
-        self.root.geometry("1024x720")
-        self.root.minsize(960, 680)
-        self.root.configure(bg="#eef2ff")
+        self.setWindowTitle("Whats My Music Flavor · 토너먼트 취향 테스트")
+        self.resize(960, 720)
 
-        self.enter_fullscreen()
+        central = QWidget()
+        self.setCentralWidget(central)
+        main_layout = QVBoxLayout(central)
+        main_layout.setContentsMargins(24, 24, 24, 24)
+        main_layout.setSpacing(16)
 
-        self.style = ttk.Style(self.root)
-        self.setup_styles()
+        title_label = QLabel("Whats My Music Flavor")
+        title_font = QFont("Pretendard", 18)
+        title_font.setBold(True)
+        title_label.setFont(title_font)
+        subtitle_label = QLabel("나만의 음악 토너먼트")
+        subtitle_font = QFont("Pretendard", 26)
+        subtitle_font.setBold(True)
+        subtitle_label.setFont(subtitle_font)
+        main_layout.addWidget(title_label)
+        main_layout.addWidget(subtitle_label)
 
-        self.valid = True
+        self.content_widget = QWidget()
+        self.content_layout = QVBoxLayout(self.content_widget)
+        self.content_layout.setContentsMargins(0, 0, 0, 0)
+        self.content_layout.setSpacing(16)
+        self.content_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        main_layout.addWidget(self.content_widget, 1)
+
+        self.status_bar = QStatusBar()
+        self.setStatusBar(self.status_bar)
+
         loader = DataLoader()
         self.songs = loader.load_songs(self.songs_file)
-
         if not self.songs or not loader.validate_songs(self.songs):
-            messagebox.showerror("데이터 오류", "곡 데이터를 불러오지 못했습니다. songs.json 파일을 확인해주세요.")
-            self.root.destroy()
+            QMessageBox.critical(self, "데이터 오류", "곡 데이터를 불러오지 못했습니다. songs.json 파일을 확인해주세요.")
             self.valid = False
             return
 
-        self.build_base_layout()
+        self.valid = True
         self.reset_state()
-        self.status_bar_var.set(f"{len(self.songs)}곡 데이터를 성공적으로 불러왔어요.")
+        self.update_status(f"{len(self.songs)}곡 데이터를 성공적으로 불러왔어요.")
 
-    def setup_styles(self):
-        self.style.theme_use("clam")
-        self.style.configure("Primary.TFrame", background="#eef2ff")
-        self.style.configure("Hero.TFrame", background="#ffffff")
-        self.style.configure("Card.TFrame", background="#ffffff", relief="flat", borderwidth=0)
-        self.style.configure("Highlight.TFrame", background="#312e81", relief="flat", borderwidth=0)
-        self.style.configure("Title.TLabel", background="#eef2ff", foreground="#1f2937", font=("Pretendard", 26, "bold"))
-        self.style.configure("HeroTitle.TLabel", background="#ffffff", foreground="#1f2937", font=("Pretendard", 28, "bold"))
-        self.style.configure("Brand.TLabel", background="#eef2ff", foreground="#4c1d95", font=("Pretendard", 18, "bold"))
-        self.style.configure("Subtitle.TLabel", background="#eef2ff", foreground="#4b5563", font=("Pretendard", 14))
-        self.style.configure("Body.TLabel", background="#ffffff", foreground="#374151", font=("Pretendard", 12))
-        self.style.configure("BodyPrimary.TLabel", background="#eef2ff", foreground="#374151", font=("Pretendard", 12))
-        self.style.configure("Subtle.TLabel", background="#ffffff", foreground="#6b7280", font=("Pretendard", 11))
-        self.style.configure("Badge.TLabel", background="#eef2ff", foreground="#4c1d95", font=("Pretendard", 11, "bold"))
-        self.style.configure("Footer.TLabel", background="#eef2ff", foreground="#6b7280", font=("Pretendard", 10))
-        self.style.configure("CardTitle.TLabel", background="#ffffff", foreground="#111827", font=("Pretendard", 18, "bold"))
-        self.style.configure("CardSubtitle.TLabel", background="#ffffff", foreground="#c7d2fe", font=("Pretendard", 12))
-        self.style.configure("CardHighlight.TLabel", background="#312e81", foreground="#ede9fe", font=("Pretendard", 24, "bold"))
-        self.style.configure("CardHighlightBody.TLabel", background="#312e81", foreground="#e0e7ff", font=("Pretendard", 12))
+    def update_status(self, message: str):
+        self.status_bar.showMessage(message)
 
-        # 설문 라디오 버튼은 선택 상태가 명확히 보이도록 별도 스타일을 사용한다.
-        self.style.configure(
-            "Survey.TRadiobutton",
-            background="#ffffff",
-            foreground="#374151",
-            font=("Pretendard", 12),
-            indicatormargin=6,
-        )
-        self.style.map(
-            "Survey.TRadiobutton",
-            foreground=[("selected", "#312e81")],
-            indicatorcolor=[("selected", "#4f46e5")],
-        )
-
-        self.style.configure("Accent.TButton", padding=12, font=("Pretendard", 12, "bold"), foreground="#ffffff", background="#6366f1")
-        self.style.map("Accent.TButton", background=[("active", "#4f46e5"), ("pressed", "#4338ca")])
-        self.style.configure("Soft.TButton", padding=12, font=("Pretendard", 12), foreground="#ffffff", background="#0ea5e9")
-        self.style.map("Soft.TButton", background=[("active", "#0284c7"), ("pressed", "#0369a1")])
-        self.style.configure("Ghost.TButton", padding=12, font=("Pretendard", 12), foreground="#4b5563", background="#ffffff")
-        self.style.map("Ghost.TButton", background=[("active", "#e5e7eb"), ("pressed", "#d1d5db")])
-
-    def build_base_layout(self):
-        self.main_frame = ttk.Frame(self.root, style="Primary.TFrame", padding=32)
-        self.main_frame.pack(fill="both", expand=True)
-
-        header = ttk.Frame(self.main_frame, style="Primary.TFrame")
-        header.pack(fill="x", pady=(0, 24))
-        ttk.Label(header, text="Whats My Music Flavor", style="Brand.TLabel").pack(anchor="w")
-        ttk.Label(header, text="나만의 음악 토너먼트", style="Title.TLabel").pack(anchor="w", pady=(8, 0))
-
-        self.content_frame = ttk.Frame(self.main_frame, style="Primary.TFrame")
-        self.content_frame.pack(fill="both", expand=True)
-
-        self.status_bar_var = tk.StringVar(value="")
-        self.status_bar = ttk.Label(self.main_frame, textvariable=self.status_bar_var, style="Footer.TLabel", anchor="w")
-        self.status_bar.pack(fill="x", pady=(24, 0))
 
     def reset_state(self):
-        self.survey_profile = {}
-        self.candidates = []
+        self.survey_profile: Dict[str, Any] = {}
+        self.candidates: List[Song] = []
         self.engine: Optional[TournamentEngine] = None
         self.bracket: List[List[Match]] = []
         self.current_round_number = 1
@@ -1439,149 +1423,135 @@ class MusicTournamentGUI:
         self.active_match: Optional[Match] = None
         self.total_matches = 0
         self.champion: Optional[Song] = None
-        self.report = {}
-        self.recommendations: Dict[str, List[Dict[str, Any]]] = {'core': [], 'fresh': []}
+        self.report: Dict[str, Any] = {}
+        self.recommendations: Dict[str, List[Dict[str, Any]]] = {"core": [], "fresh": []}
         self.seed_scores: Dict[str, float] = {}
 
-    def enter_fullscreen(self):
-        """Try to expand the root window to full screen."""
-        try:
-            self.root.state("zoomed")
-        except tk.TclError:
-            try:
-                self.root.attributes("-zoomed", True)
-            except tk.TclError:
-                screen_width = self.root.winfo_screenwidth()
-                screen_height = self.root.winfo_screenheight()
-                self.root.geometry(f"{screen_width}x{screen_height}+0+0")
 
     def clear_content(self):
-        for child in self.content_frame.winfo_children():
-            child.destroy()
+        while self.content_layout.count():
+            item = self.content_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
 
     def show_start_view(self):
         self.reset_state()
         self.clear_content()
 
-        hero = ttk.Frame(self.content_frame, style="Hero.TFrame", padding=48)
-        hero.pack(expand=True, fill="both", pady=12)
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.setSpacing(12)
+        layout.addWidget(QLabel("당신의 음악 취향을 발견해보세요"))
+        intro = QLabel("간단한 설문과 토너먼트를 통해 나만의 플레이리스트를 만들어보세요.")
+        intro.setWordWrap(True)
+        layout.addWidget(intro)
 
-        ttk.Label(hero, text="당신의 음악 취향을 시각적으로 발견해보세요", style="HeroTitle.TLabel", wraplength=680).pack(anchor="w")
-        ttk.Label(
-            hero,
-            text="장르 선호부터 토너먼트 챔피언 선정, 추천곡까지 한 번에 경험할 수 있는 인터랙티브 테스트입니다.",
-            style="Body.TLabel",
-            wraplength=700,
-            padding=(0, 20)
-        ).pack(anchor="w")
+        start_button = QPushButton("지금 시작하기")
+        start_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        start_button.clicked.connect(self.show_survey_view)
+        layout.addWidget(start_button, alignment=Qt.AlignmentFlag.AlignLeft)
 
-        highlights = ttk.Frame(hero, style="Hero.TFrame")
-        highlights.pack(anchor="w", pady=(0, 24))
-        for text in [
-            "🎧 간단한 설문으로 나만의 음악 DNA 분석",
-            "⚔️ 두 곡 중 하나를 선택하며 즐기는 토너먼트",
-            "✨ 토너먼트 기록 기반 맞춤 추천 리스트"
-        ]:
-            row = ttk.Frame(highlights, style="Hero.TFrame")
-            row.pack(anchor="w", pady=6)
-            ttk.Label(row, text=text, style="Body.TLabel").pack(anchor="w")
-
-        ttk.Button(hero, text="지금 시작하기", style="Accent.TButton", command=self.show_survey_view).pack(anchor="w", pady=(12, 0))
-        self.status_bar_var.set("간단한 설문부터 시작해볼까요?")
+        self.content_layout.addWidget(widget)
+        self.update_status("간단한 설문부터 시작해볼까요?")
 
     def show_survey_view(self):
         self.clear_content()
 
-        container = ttk.Frame(self.content_frame, style="Primary.TFrame")
-        container.pack(fill="both", expand=True)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        form = QWidget()
+        form_layout = QVBoxLayout(form)
+        form_layout.setSpacing(12)
 
-        card = ttk.Frame(container, style="Card.TFrame", padding=32)
-        card.pack(fill="both", expand=True, padx=12, pady=12)
-
-        ttk.Label(card, text="나의 음악 스타일 진단", style="CardTitle.TLabel").pack(anchor="w")
-        ttk.Label(card, text="선호에 가장 가까운 선택지를 골라주세요. 토너먼트에 활용됩니다.", style="Subtle.TLabel").pack(anchor="w", pady=(4, 24))
-
-        genre_section = ttk.Frame(card, style="Card.TFrame")
-        genre_section.pack(fill="x", pady=(0, 24))
-        ttk.Label(genre_section, text="장르 밸런스", style="Body.TLabel").pack(anchor="w", pady=(0, 8))
-
-        self.genre_vars = []
+        self.genre_groups: List[Tuple[QButtonGroup, Tuple[str, str]]] = []
         for idx, (g1, g2) in enumerate(self.GENRE_PAIRS, 1):
-            row = ttk.Frame(genre_section, style="Card.TFrame")
-            row.pack(fill="x", pady=6)
-            ttk.Label(row, text=f"{idx}. {g1} vs {g2}", style="Subtle.TLabel").pack(anchor="w")
-            var = tk.StringVar(value="")
-            self.genre_vars.append((var, (g1, g2)))
-            options = ttk.Frame(row, style="Card.TFrame")
-            options.pack(anchor="w", pady=(6, 0))
-            ttk.Radiobutton(options, text=f"{g1} 선호", variable=var, value='1', style="Survey.TRadiobutton").pack(side="left", padx=(0, 16))
-            ttk.Radiobutton(options, text=f"{g2} 선호", variable=var, value='2', style="Survey.TRadiobutton").pack(side="left", padx=(0, 16))
-            ttk.Radiobutton(options, text="잘 모르겠음", variable=var, value='s', style="Survey.TRadiobutton").pack(side="left")
+            box = QGroupBox(f"{idx}. {g1} vs {g2}")
+            box_layout = QHBoxLayout(box)
+            group = QButtonGroup(box)
+            for text, value in ((f"{g1} 선호", "1"), (f"{g2} 선호", "2"), ("잘 모르겠음", "s")):
+                btn = QRadioButton(text)
+                btn.setProperty("value", value)
+                btn.setCursor(Qt.CursorShape.PointingHandCursor)
+                group.addButton(btn)
+                box_layout.addWidget(btn)
+            self.genre_groups.append((group, (g1, g2)))
+            form_layout.addWidget(box)
 
-        def build_radio_section(parent, title, options, var):
-            section = ttk.Frame(parent, style="Card.TFrame")
-            section.pack(fill="x", pady=12)
-            ttk.Label(section, text=title, style="Body.TLabel").pack(anchor="w")
-            radios = ttk.Frame(section, style="Card.TFrame")
-            radios.pack(anchor="w", pady=(6, 0))
-            for text, value in options:
-                ttk.Radiobutton(radios, text=text, variable=var, value=value, style="Survey.TRadiobutton").pack(side="left", padx=(0, 16))
+        self.era_group = self.build_radio_section(form_layout, "시대 선호", self.ERA_OPTIONS, default="2")
+        self.energy_group = self.build_radio_section(form_layout, "에너지 레벨", self.ENERGY_OPTIONS, default="3")
+        self.popularity_group = self.build_radio_section(form_layout, "인기도 선호", self.POPULARITY_OPTIONS, default="2")
+        self.language_group = self.build_radio_section(form_layout, "가사 언어", self.LANGUAGE_OPTIONS, default="4")
+        self.language_focus_group = self.build_radio_section(form_layout, "언어 집중도", self.LANGUAGE_FOCUS_OPTIONS, default="4")
+        self.regional_focus_group = self.build_radio_section(form_layout, "국가/지역 취향", self.REGIONAL_FOCUS_OPTIONS, default="4")
 
-        self.era_var = tk.StringVar(value='2')
-        self.energy_var = tk.StringVar(value='3')
-        self.popularity_var = tk.StringVar(value='2')
-        self.language_var = tk.StringVar(value='4')
-        self.language_focus_var = tk.StringVar(value='4')
-        self.regional_focus_var = tk.StringVar(value='4')
+        start_button = QPushButton("토너먼트 시작")
+        start_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        start_button.clicked.connect(self.begin_tournament)
+        form_layout.addWidget(start_button, alignment=Qt.AlignmentFlag.AlignRight)
+        form_layout.addStretch(1)
 
-        build_radio_section(card, "가장 마음에 드는 음악 시대", self.ERA_OPTIONS, self.era_var)
-        build_radio_section(card, "에너지 레벨", self.ENERGY_OPTIONS, self.energy_var)
-        build_radio_section(card, "인지도 선호", self.POPULARITY_OPTIONS, self.popularity_var)
-        build_radio_section(card, "가사 언어", self.LANGUAGE_OPTIONS, self.language_var)
-        build_radio_section(card, "언어 집중도", self.LANGUAGE_FOCUS_OPTIONS, self.language_focus_var)
-        build_radio_section(card, "국가/지역 취향", self.REGIONAL_FOCUS_OPTIONS, self.regional_focus_var)
+        scroll.setWidget(form)
+        self.content_layout.addWidget(scroll)
+        self.update_status("설문 응답을 바탕으로 맞춤 토너먼트를 준비합니다.")
 
-        ttk.Button(card, text="토너먼트 시작", style="Accent.TButton", command=self.begin_tournament).pack(anchor="e", pady=(24, 0))
-        self.status_bar_var.set("설문 응답을 바탕으로 맞춤 토너먼트를 준비합니다.")
+    def build_radio_section(self, layout: QVBoxLayout, title: str, options: List[Tuple[str, str]], default: Optional[str] = None) -> QButtonGroup:
+        box = QGroupBox(title)
+        box_layout = QHBoxLayout(box)
+        group = QButtonGroup(box)
+        for text, value in options:
+            btn = QRadioButton(text)
+            btn.setProperty("value", value)
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            if default is not None and value == default:
+                btn.setChecked(True)
+            group.addButton(btn)
+            box_layout.addWidget(btn)
+        layout.addWidget(box)
+        return group
 
     def begin_tournament(self):
-        genre_scores = defaultdict(int)
-        for var, (g1, g2) in self.genre_vars:
-            choice = var.get()
-            if choice == '1':
+        genre_scores: Dict[str, int] = defaultdict(int)
+        for group, (g1, g2) in self.genre_groups:
+            button = group.checkedButton()
+            if not button:
+                continue
+            value = button.property("value")
+            if value == "1":
                 genre_scores[g1] += 1
-            elif choice == '2':
+            elif value == "2":
                 genre_scores[g2] += 1
 
-        era_map = {'1': 1980, '2': 2000, '3': 2015, '4': None}
-        energy_map = {'1': 0.2, '2': 0.5, '3': 0.7, '4': 0.9}
-        pop_map = {'1': 0.8, '2': 0.5, '3': 0.2}
-        lang_map = {'1': 'ko', '2': 'en', '3': 'other', '4': None}
-        global_languages = {'en', 'es', 'fr', 'instrumental'}
+        era_map = {"1": 1980, "2": 2000, "3": 2015, "4": None}
+        energy_map = {"1": 0.2, "2": 0.5, "3": 0.7, "4": 0.9}
+        pop_map = {"1": 0.8, "2": 0.5, "3": 0.2}
+        lang_map = {"1": "ko", "2": "en", "3": "other", "4": None}
+        global_languages = {"en", "es", "fr", "instrumental"}
         language_focus_map = {
-            '1': {'languages': {'ko'}, 'strict': True},
-            '2': {'languages': {'ko', 'en'}, 'strict': True},
-            '3': {'languages': global_languages, 'strict': True},
-            '4': {'languages': set(), 'strict': False},
+            "1": {"languages": {"ko"}, "strict": True},
+            "2": {"languages": {"ko", "en"}, "strict": True},
+            "3": {"languages": global_languages, "strict": True},
+            "4": {"languages": set(), "strict": False},
         }
-        regional_focus_map = {
-            '1': 'k_only',
-            '2': 'k_prefer',
-            '3': 'global',
-            '4': 'neutral',
-        }
-        language_focus = language_focus_map.get(self.language_focus_var.get(), {'languages': set(), 'strict': False})
-        regional_focus = regional_focus_map.get(self.regional_focus_var.get(), 'neutral')
+        regional_focus_map = {"1": "k_only", "2": "k_prefer", "3": "global", "4": "neutral"}
+
+        def group_value(group: QButtonGroup, default: str) -> str:
+            button = group.checkedButton()
+            return button.property("value") if button else default
+
+        lang_focus_value = group_value(self.language_focus_group, "4")
+        language_focus = language_focus_map.get(lang_focus_value, {"languages": set(), "strict": False})
+        regional_focus = regional_focus_map.get(group_value(self.regional_focus_group, "4"), "neutral")
 
         self.survey_profile = {
-            'genre_scores': dict(genre_scores),
-            'preferred_era': era_map.get(self.era_var.get()),
-            'preferred_energy': energy_map.get(self.energy_var.get(), 0.5),
-            'preferred_popularity': pop_map.get(self.popularity_var.get(), 0.5),
-            'preferred_language': lang_map.get(self.language_var.get()),
-            'preferred_languages': sorted(language_focus['languages']),
-            'language_strict': language_focus['strict'],
-            'regional_focus': regional_focus
+            "genre_scores": dict(genre_scores),
+            "preferred_era": era_map.get(group_value(self.era_group, "2")),
+            "preferred_energy": energy_map.get(group_value(self.energy_group, "3"), 0.5),
+            "preferred_popularity": pop_map.get(group_value(self.popularity_group, "2"), 0.5),
+            "preferred_language": lang_map.get(group_value(self.language_group, "4")),
+            "preferred_languages": sorted(language_focus["languages"]),
+            "language_strict": language_focus["strict"],
+            "regional_focus": regional_focus,
         }
 
         selector = CandidateSelector(self.songs, self.survey_profile)
@@ -1589,7 +1559,7 @@ class MusicTournamentGUI:
         self.seed_scores = selector.get_seed_scores()
 
         if len(self.candidates) < 2:
-            messagebox.showwarning("후보 부족", "토너먼트를 진행하기에 곡이 부족합니다. 데이터를 확인해주세요.")
+            QMessageBox.warning(self, "후보 부족", "토너먼트를 진행하기에 곡이 부족합니다. 데이터를 확인해주세요.")
             self.show_start_view()
             return
 
@@ -1602,137 +1572,132 @@ class MusicTournamentGUI:
         bracket_gen = BracketGenerator()
         self.bracket = bracket_gen.create_bracket(self.candidates, self.seed_scores)
         if not self.bracket:
-            messagebox.showwarning("브래킷 생성 실패", "토너먼트를 구성할 수 있는 매치가 부족합니다. 응답을 조정해보세요.")
+            QMessageBox.warning(self, "브래킷 생성 실패", "토너먼트를 구성할 수 있는 매치가 부족합니다. 응답을 조정해보세요.")
             self.show_start_view()
             return
+
         self.current_round_number = 1
         self.current_round_matches = self.bracket[0] if self.bracket else []
         self.current_round_winners = []
         self.current_match_index = 0
         self.total_matches = max(1, len(self.candidates) - 1)
-        self.progress_value = 0
 
-        self.status_bar_var.set("토너먼트를 준비 중입니다.")
+        self.update_status("토너먼트를 준비 중입니다.")
         self.show_match_view()
 
     def show_match_view(self):
         self.clear_content()
 
-        container = ttk.Frame(self.content_frame, style="Primary.TFrame")
-        container.pack(fill="both", expand=True)
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setSpacing(12)
+        layout.addWidget(QLabel("토너먼트 진행"))
 
-        ttk.Label(container, text="토너먼트 진행", style="Title.TLabel").pack(anchor="w")
-        self.status_var = tk.StringVar(value="")
-        ttk.Label(container, textvariable=self.status_var, style="BodyPrimary.TLabel").pack(anchor="w", pady=(6, 16))
+        self.match_status_label = QLabel()
+        layout.addWidget(self.match_status_label)
 
-        self.progress_bar = ttk.Progressbar(container, maximum=100, value=0, length=520)
-        self.progress_bar.pack(fill="x", pady=(0, 24))
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setRange(0, 100)
+        layout.addWidget(self.progress_bar)
 
-        cards = ttk.Frame(container, style="Primary.TFrame")
-        cards.pack(fill="both", expand=True)
-        cards.columnconfigure(0, weight=1)
-        cards.columnconfigure(1, weight=1)
+        cards_container = QWidget()
+        cards_layout = QHBoxLayout(cards_container)
+        self.card_a = self.create_song_card(cards_container, "A 곡")
+        self.card_b = self.create_song_card(cards_container, "B 곡")
+        cards_layout.addWidget(self.card_a["box"])
+        cards_layout.addWidget(self.card_b["box"])
+        layout.addWidget(cards_container)
 
-        self.card_a = self.create_song_card(cards, "A 곡")
-        self.card_a["frame"].grid(row=0, column=0, sticky="nsew", padx=(0, 12))
+        self.helper_label = QLabel("마음에 드는 곡을 선택하세요.")
+        layout.addWidget(self.helper_label)
 
-        self.card_b = self.create_song_card(cards, "B 곡")
-        self.card_b["frame"].grid(row=0, column=1, sticky="nsew", padx=(12, 0))
+        button_row = QWidget()
+        button_layout = QGridLayout(button_row)
+        button_layout.setSpacing(8)
 
-        self.helper_var = tk.StringVar(value="마음에 드는 곡을 선택하세요.")
-        ttk.Label(container, textvariable=self.helper_var, style="BodyPrimary.TLabel").pack(anchor="center", pady=(24, 12))
+        def add_button(text: str, row: int, col: int, choice: str):
+            button = QPushButton(text)
+            button.setCursor(Qt.CursorShape.PointingHandCursor)
+            button.clicked.connect(lambda _=False, c=choice: self.on_choice(c))
+            button_layout.addWidget(button, row, col)
 
-        button_frame = ttk.Frame(container, style="Primary.TFrame")
-        button_frame.pack(pady=(0, 24))
-        button_frame.columnconfigure(0, weight=1)
-        button_frame.columnconfigure(1, weight=1)
+        add_button("A 곡 선택", 0, 0, "A")
+        add_button("B 곡 선택", 0, 1, "B")
+        add_button("둘 다 좋아요", 1, 0, "T")
+        add_button("건너뛰기", 1, 1, "S")
+        layout.addWidget(button_row)
 
-        ttk.Button(button_frame, text="A 곡 선택", style="Accent.TButton", command=lambda: self.on_choice('A')).grid(row=0, column=0, padx=8, pady=6, sticky="ew")
-        ttk.Button(button_frame, text="B 곡 선택", style="Accent.TButton", command=lambda: self.on_choice('B')).grid(row=0, column=1, padx=8, pady=6, sticky="ew")
-        ttk.Button(button_frame, text="둘 다 좋아요", style="Soft.TButton", command=lambda: self.on_choice('T')).grid(row=1, column=0, padx=8, pady=6, sticky="ew")
-        ttk.Button(button_frame, text="건너뛰기", style="Ghost.TButton", command=lambda: self.on_choice('S')).grid(row=1, column=1, padx=8, pady=6, sticky="ew")
-
-        self.status_bar_var.set("토너먼트가 진행 중입니다. 클릭 한 번으로 선택하세요!")
+        self.content_layout.addWidget(container)
+        self.update_status("토너먼트가 진행 중입니다. 클릭 한 번으로 선택하세요!")
         self.display_current_match()
 
-    def create_song_card(self, parent, label_text: str):
-        frame = ttk.Frame(parent, style="Card.TFrame", padding=24)
-        ttk.Label(frame, text=label_text, style="Badge.TLabel").pack(anchor="w")
+    def create_song_card(self, parent: QWidget, title: str):
+        box = QGroupBox(title)
+        layout = QVBoxLayout(box)
+        name_label = QLabel()
+        layout.addWidget(name_label)
+        meta_label = QLabel()
+        layout.addWidget(meta_label)
+        tag_label = QLabel()
+        tag_label.setWordWrap(True)
+        layout.addWidget(tag_label)
+        link_label = QLabel()
+        link_label.setTextFormat(Qt.TextFormat.RichText)
+        link_label.setOpenExternalLinks(True)
+        layout.addWidget(link_label)
+        return {"box": box, "title": name_label, "meta": meta_label, "tag": tag_label, "link": link_label}
 
-        title_var = tk.StringVar(value="")
-        ttk.Label(frame, textvariable=title_var, style="CardTitle.TLabel", wraplength=360).pack(anchor="w", pady=(12, 4))
 
-        meta_var = tk.StringVar(value="")
-        ttk.Label(frame, textvariable=meta_var, style="Body.TLabel", wraplength=360).pack(anchor="w")
-
-        tag_var = tk.StringVar(value="")
-        ttk.Label(frame, textvariable=tag_var, style="Subtle.TLabel", wraplength=360).pack(anchor="w", pady=(8, 0))
-
-        link_label = tk.Label(frame, text="", font=("Pretendard", 11, "underline"), fg="#2563eb", bg="#ffffff", cursor="hand2")
-        link_label.pack(anchor="w", pady=(12, 0))
-
-        return {
-            "frame": frame,
-            "title": title_var,
-            "meta": meta_var,
-            "tag": tag_var,
-            "link": link_label
-        }
-
-    def update_song_card(self, card, song: Song):
-        card["title"].set(song.get_display_title())
+    def update_song_card(self, card: Dict[str, QLabel], song: Song):
+        card["title"].setText(song.get_display_title())
         rating = song.rating if song.rating else 1500
-        card["meta"].set(f"{song.artist} · 예상 레이팅 {rating:.0f}")
-
-        details = []
-        if song.tags.get('era_year'):
+        card["meta"].setText(f"{song.artist} · 예상 레이팅 {rating:.0f}")
+        details: List[str] = []
+        if song.tags.get("era_year"):
             details.append(f"{song.tags['era_year']}년대")
-        if song.tags.get('energy') is not None:
+        if song.tags.get("energy") is not None:
             details.append(f"에너지 {song.tags['energy']*100:.0f}%")
         if song.genres:
-            details.append(f"장르 {', '.join(song.genres[:2])}")
+            details.append("장르 " + ", ".join(song.genres[:2]))
         elif song.genre_codes:
-            details.append(f"장르 코드 {', '.join(map(str, song.genre_codes[:3]))}")
-        card["tag"].set(" · ".join(details))
-
-        link_label = card["link"]
-        link_label.unbind("<Button-1>")
+            details.append("장르 코드 " + ", ".join(map(str, song.genre_codes[:3])))
+        card["tag"].setText(" · ".join(details))
         if song.youtube_url:
-            link_label.configure(text="YouTube에서 듣기 ↗", fg="#2563eb", cursor="hand2")
-            link_label.bind("<Button-1>", lambda _event, url=song.youtube_url: webbrowser.open(url))
+            card["link"].setOpenExternalLinks(True)
+            card["link"].setText(f'<a href="{song.youtube_url}">YouTube에서 듣기 ↗</a>')
         else:
-            link_label.configure(text="링크 정보가 없습니다", fg="#9ca3af", cursor="arrow")
+            card["link"].setOpenExternalLinks(False)
+            card["link"].setText("<span style='color:#9ca3af;'>링크 정보가 없습니다</span>")
 
     def display_current_match(self):
         if not self.current_round_matches:
-            self.finish_tournament(self.current_round_winners[0] if self.current_round_winners else None)
+            champion = self.current_round_winners[0] if self.current_round_winners else None
+            self.finish_tournament(champion)
             return
-
         if self.current_match_index >= len(self.current_round_matches):
             self.prepare_next_round()
             return
 
         self.active_match = self.current_round_matches[self.current_match_index]
         match = self.active_match
-        self.status_var.set(f"라운드 {self.current_round_number} · 매치 {self.current_match_index + 1}/{len(self.current_round_matches)}")
-        self.helper_var.set(f"{match.song_a.artist} vs {match.song_b.artist}")
+        self.match_status_label.setText(
+            f"라운드 {self.current_round_number} · 매치 {self.current_match_index + 1}/{len(self.current_round_matches)}"
+        )
+        self.helper_label.setText(f"{match.song_a.artist} vs {match.song_b.artist}")
         self.update_song_card(self.card_a, match.song_a)
         self.update_song_card(self.card_b, match.song_b)
-
         progress_ratio = len(self.engine.match_history) / self.total_matches if self.total_matches else 0
-        self.progress_bar.configure(value=progress_ratio * 100)
+        self.progress_bar.setValue(int(progress_ratio * 100))
 
     def on_choice(self, choice: str):
         if not self.active_match or not self.engine:
             return
-
         winner = self.engine.resolve_match(self.active_match, choice)
         if winner:
             self.current_round_winners.append(winner)
-
         self.current_match_index += 1
         progress_ratio = len(self.engine.match_history) / self.total_matches if self.total_matches else 0
-        self.progress_bar.configure(value=progress_ratio * 100)
+        self.progress_bar.setValue(int(progress_ratio * 100))
         self.display_current_match()
 
     def prepare_next_round(self):
@@ -1740,23 +1705,19 @@ class MusicTournamentGUI:
         if not winners:
             self.finish_tournament(None)
             return
-
         if len(winners) == 1:
             self.finish_tournament(winners[0])
             return
-
         self.current_round_number += 1
-        next_round = []
+        next_round: List[Match] = []
         for i in range(0, len(winners), 2):
             if i + 1 < len(winners):
-                match = Match(
+                next_round.append(Match(
                     round_num=self.current_round_number,
-                    match_id=f"R{self.current_round_number}-M{i//2 + 1}",
+                    match_id=f"R{self.current_round_number}-M{i // 2 + 1}",
                     song_a=winners[i],
-                    song_b=winners[i + 1]
-                )
-                next_round.append(match)
-
+                    song_b=winners[i + 1],
+                ))
         self.current_round_matches = next_round
         self.current_round_winners = []
         self.current_match_index = 0
@@ -1768,163 +1729,85 @@ class MusicTournamentGUI:
 
     def show_results_view(self):
         self.clear_content()
-
-        container = ttk.Frame(self.content_frame, style="Primary.TFrame")
-        container.pack(fill="both", expand=True)
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setSpacing(12)
+        self.content_layout.addWidget(container)
 
         if not self.champion or not self.engine:
-            ttk.Label(container, text="토너먼트 결과가 존재하지 않습니다.", style="BodyPrimary.TLabel").pack(pady=24)
-            ttk.Button(container, text="처음으로", style="Ghost.TButton", command=self.show_start_view).pack()
+            message = QLabel("토너먼트 결과가 존재하지 않습니다.")
+            layout.addWidget(message)
+            back = QPushButton("처음으로")
+            back.setCursor(Qt.CursorShape.PointingHandCursor)
+            back.clicked.connect(self.show_start_view)
+            layout.addWidget(back, alignment=Qt.AlignmentFlag.AlignLeft)
+            self.update_status("토너먼트 결과가 없습니다.")
             return
 
         analyzer = ResultAnalyzer(self.engine.match_history, self.candidates)
         self.report = analyzer.generate_report(self.champion)
         recommender = RecommendationEngine(self.songs, self.candidates, self.survey_profile)
-        self.recommendations = recommender.generate_recommendations(self.report['top_songs'])
+        self.recommendations = recommender.generate_recommendations(self.report["top_songs"])
 
-        highlight = ttk.Frame(container, style="Highlight.TFrame", padding=32)
-        highlight.pack(fill="x", padx=12, pady=(0, 24))
-
-        ttk.Label(highlight, text="우승 곡", style="CardSubtitle.TLabel").pack(anchor="w")
-        ttk.Label(highlight, text=str(self.champion), style="CardHighlight.TLabel").pack(anchor="w", pady=(8, 6))
-        ttk.Label(
-            highlight,
-            text=f"최종 레이팅 {self.champion.rating:.1f} · 전적 {self.champion.wins}승 {self.champion.losses}패",
-            style="CardHighlightBody.TLabel"
-        ).pack(anchor="w")
-
-        link = tk.Label(highlight, text="YouTube에서 우승 곡 감상하기 ↗", font=("Pretendard", 12, "underline"),
-                        fg="#c4b5fd", bg="#312e81", cursor="hand2")
-        link.pack(anchor="w", pady=(12, 0))
+        champion_label = QLabel(f"우승 곡: {self.champion}")
+        layout.addWidget(champion_label)
+        record_label = QLabel(
+            f"레이팅 {self.champion.rating:.1f} · 전적 {self.champion.wins}승 {self.champion.losses}패"
+        )
+        layout.addWidget(record_label)
         if self.champion.youtube_url:
-            link.bind("<Button-1>", lambda _event, url=self.champion.youtube_url: webbrowser.open(url))
-        else:
-            link.configure(text="YouTube 링크 정보가 없습니다", fg="#a78bfa", cursor="arrow")
+            link = QLabel(f'<a href="{self.champion.youtube_url}">YouTube에서 우승 곡 듣기 ↗</a>')
+            link.setTextFormat(Qt.TextFormat.RichText)
+            link.setOpenExternalLinks(True)
+            layout.addWidget(link)
 
-        grid = ttk.Frame(container, style="Primary.TFrame")
-        grid.pack(fill="both", expand=True)
-        grid.columnconfigure(0, weight=1)
-        grid.columnconfigure(1, weight=1)
+        if self.report["top_songs"]:
+            layout.addWidget(QLabel("상위 플레이리스트"))
+            for idx, song in enumerate(self.report["top_songs"], 1):
+                layout.addWidget(QLabel(f"{idx}. {song}"))
 
-        top_card = ttk.Frame(grid, style="Card.TFrame", padding=24)
-        top_card.grid(row=0, column=0, sticky="nsew", padx=(0, 12), pady=(0, 24))
-        ttk.Label(top_card, text="상위 플레이리스트", style="CardTitle.TLabel").pack(anchor="w")
+        stats = self.report["choice_distribution"]
+        layout.addWidget(QLabel(
+            f"총 매치 {self.report['total_matches']} · A {stats.get('A', 0)} · B {stats.get('B', 0)} · 둘 다 {stats.get('T', 0)} · 건너뛰기 {stats.get('S', 0)}"
+        ))
 
-        for i, song in enumerate(self.report['top_songs'], 1):
-            item = ttk.Frame(top_card, style="Card.TFrame")
-            item.pack(fill="x", pady=6)
-            ttk.Label(item, text=f"{i}. {song}", style="Body.TLabel").pack(anchor="w")
-            ttk.Label(item, text=f"레이팅 {song.rating:.1f} · 전적 {song.wins}승 {song.losses}패", style="Subtle.TLabel").pack(anchor="w")
+        self.render_recommendations(layout)
 
-        stats_card = ttk.Frame(grid, style="Card.TFrame", padding=24)
-        stats_card.grid(row=0, column=1, sticky="nsew", padx=(12, 0), pady=(0, 24))
-        ttk.Label(stats_card, text="매치 통계", style="CardTitle.TLabel").pack(anchor="w")
+        back_button = QPushButton("처음으로 돌아가기")
+        back_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        back_button.clicked.connect(self.show_start_view)
+        layout.addWidget(back_button, alignment=Qt.AlignmentFlag.AlignLeft)
+        self.update_status("결과를 확인하고 추천곡을 감상해보세요.")
 
-        stats = self.report['choice_distribution']
-        ttk.Label(stats_card, text=f"총 매치: {self.report['total_matches']}", style="Body.TLabel").pack(anchor="w", pady=(8, 2))
-        ttk.Label(stats_card, text=f"A 선택: {stats.get('A', 0)}", style="Subtle.TLabel").pack(anchor="w")
-        ttk.Label(stats_card, text=f"B 선택: {stats.get('B', 0)}", style="Subtle.TLabel").pack(anchor="w")
-        ttk.Label(stats_card, text=f"둘 다: {stats.get('T', 0)}", style="Subtle.TLabel").pack(anchor="w")
-        ttk.Label(stats_card, text=f"건너뛰기: {stats.get('S', 0)}", style="Subtle.TLabel").pack(anchor="w")
-
-        recommend_card = ttk.Frame(container, style="Card.TFrame", padding=24)
-        recommend_card.pack(fill="both", expand=True, padx=12, pady=(0, 24))
-        ttk.Label(recommend_card, text="맞춤 추천", style="CardTitle.TLabel").pack(anchor="w")
-
-        scroll_container = ttk.Frame(recommend_card, style="Card.TFrame")
-        scroll_container.pack(fill="both", expand=True, pady=(12, 0))
-
-        canvas = tk.Canvas(scroll_container, background="#ffffff", highlightthickness=0, bd=0)
-        canvas.pack(side="left", fill="both", expand=True)
-
-        scrollbar = ttk.Scrollbar(scroll_container, orient="vertical", command=canvas.yview)
-        scrollbar.pack(side="right", fill="y")
-        canvas.configure(yscrollcommand=scrollbar.set)
-
-        scrollable_frame = ttk.Frame(canvas, style="Card.TFrame")
-        window_id = canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
-
-        def _on_frame_configure(_event):
-            canvas.configure(scrollregion=canvas.bbox("all"))
-
-        def _on_canvas_configure(event):
-            canvas.itemconfigure(window_id, width=event.width)
-
-        def _on_mousewheel(event):
-            delta = 0
-            if event.delta:
-                normalized = -event.delta / 120
-                if normalized == 0:
-                    delta = -1 if event.delta > 0 else 1
-                else:
-                    magnitude = math.ceil(abs(normalized))
-                    delta = int(math.copysign(magnitude, normalized))
-            elif event.num in (4, 5):
-                delta = -1 if event.num == 4 else 1
-
-            if delta:
-                canvas.yview_scroll(delta, "units")
-            return "break"
-
-        def _bind_to_mousewheel(_event):
-            canvas.bind_all("<MouseWheel>", _on_mousewheel)
-            canvas.bind_all("<Button-4>", _on_mousewheel)
-            canvas.bind_all("<Button-5>", _on_mousewheel)
-
-        def _unbind_from_mousewheel(_event):
-            canvas.unbind_all("<MouseWheel>")
-            canvas.unbind_all("<Button-4>")
-            canvas.unbind_all("<Button-5>")
-
-        scrollable_frame.bind("<Configure>", _on_frame_configure)
-        canvas.bind("<Configure>", _on_canvas_configure)
-        scrollable_frame.bind("<Enter>", _bind_to_mousewheel)
-        scrollable_frame.bind("<Leave>", _unbind_from_mousewheel)
-        scrollable_frame.bind("<Destroy>", _unbind_from_mousewheel)
-
-        core_recs = self.recommendations.get('core', []) if self.recommendations else []
-        fresh_recs = self.recommendations.get('fresh', []) if self.recommendations else []
-
+    def render_recommendations(self, layout: QVBoxLayout):
+        layout.addWidget(QLabel("맞춤 추천"))
+        core_recs = self.recommendations.get("core", []) if self.recommendations else []
+        fresh_recs = self.recommendations.get("fresh", []) if self.recommendations else []
         if not core_recs and not fresh_recs:
-            ttk.Label(scrollable_frame, text="추천할 곡이 없습니다.", style="Subtle.TLabel").pack(anchor="w", pady=12)
-        else:
-            def render_section(title: str, entries: List[Dict[str, Any]]):
-                ttk.Label(scrollable_frame, text=title, style="CardSubtitle.TLabel").pack(anchor="w", pady=(8, 4))
-                for idx, entry in enumerate(entries, 1):
-                    song = entry['song']
-                    reason = entry['reason']
-                    item = ttk.Frame(scrollable_frame, style="Card.TFrame")
-                    item.pack(fill="x", pady=6)
-                    ttk.Label(item, text=f"{idx}. {song}", style="Body.TLabel").pack(anchor="w")
-                    ttk.Label(item, text=reason, style="Subtle.TLabel", wraplength=620, justify="left").pack(anchor="w")
-                    link_label = tk.Label(
-                        item,
-                        text="YouTube에서 듣기 ↗",
-                        font=("Pretendard", 11, "underline"),
-                        fg="#2563eb",
-                        bg="#ffffff",
-                        cursor="hand2"
-                    )
-                    link_label.pack(anchor="w", pady=(4, 0))
-                    if song.youtube_url:
-                        link_label.bind("<Button-1>", lambda _event, url=song.youtube_url: webbrowser.open(url))
-                    else:
-                        link_label.configure(text="링크 정보가 없습니다", fg="#9ca3af", cursor="arrow")
-
-            if core_recs:
-                render_section("🎯 취향 저격 트랙", core_recs)
-
-            if fresh_recs:
-                render_section("🌱 새롭게 시도해볼 곡", fresh_recs)
-
-        ttk.Button(container, text="처음으로 돌아가기", style="Ghost.TButton", command=self.show_start_view).pack(pady=(0, 12))
-        self.status_bar_var.set("결과를 확인하고 추천곡을 감상해보세요.")
+            layout.addWidget(QLabel("추천할 곡이 없습니다."))
+            return
+        for title, entries in (("🎯 취향 저격 트랙", core_recs), ("🌱 새롭게 시도해볼 곡", fresh_recs)):
+            if not entries:
+                continue
+            layout.addWidget(QLabel(title))
+            for idx, entry in enumerate(entries, 1):
+                song = entry["song"]
+                reason = entry["reason"]
+                layout.addWidget(QLabel(f"{idx}. {song}"))
+                reason_label = QLabel(reason)
+                reason_label.setWordWrap(True)
+                layout.addWidget(reason_label)
+                if song.youtube_url:
+                    link = QLabel(f'<a href="{song.youtube_url}">YouTube에서 듣기 ↗</a>')
+                    link.setTextFormat(Qt.TextFormat.RichText)
+                    link.setOpenExternalLinks(True)
+                    layout.addWidget(link)
 
     def run(self):
         if not self.valid:
             return
         self.show_start_view()
-        self.root.mainloop()
+        self.show()
 # ============================================================================
 # 실행
 # ============================================================================
@@ -1936,8 +1819,12 @@ def main():
         print("✗ songs.json 파일을 찾을 수 없습니다. 프로젝트 루트에 파일을 추가해주세요.")
         return
 
+    app = QApplication(sys.argv)
     gui = MusicTournamentGUI(str(songs_file))
+    if not gui.valid:
+        return
     gui.run()
+    app.exec()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- migrate the desktop interface from Tkinter to a PyQt6-based `MusicTournamentGUI`
- recreate the survey, tournament, and results flows with PyQt widgets and layouts
- update the program entrypoint to start a `QApplication` before launching the GUI

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68da017d85e4832ba4f73a7aa12b01ee