### PR TITLE
Reduce footer call-to-action height

### DIFF
--- a/main.py
+++ b/main.py
@@ -1910,6 +1910,7 @@ class MusicTournamentGUI(QMainWindow):
         footer_layout.addWidget(footer_notice, 1)
 
         self.report_issue_button = QPushButton("문제 신고 · 개선 제안하기")
+        self.report_issue_button.setObjectName("ReportIssueButton")
         self.report_issue_button.setProperty("variant", "primary")
         self.report_issue_button.clicked.connect(self.open_issue_link)
         footer_layout.addWidget(self.report_issue_button, 0, Qt.AlignmentFlag.AlignRight)
@@ -2122,8 +2123,8 @@ QLabel#RecommendationGroupLabel {
 }
 QLabel#FooterNotice {
     color: #94a3b8;
-    font-size: 13px;
-    line-height: 1.35em;
+    font-size: 11px;
+    line-height: 1.2em;
 }
 QPushButton {
     background-color: rgba(148, 163, 184, 0.18);
@@ -2133,6 +2134,11 @@ QPushButton {
     color: #e2e8f0;
     font-weight: 600;
     min-height: 36px;
+}
+QPushButton#ReportIssueButton {
+    padding: 4px 12px;
+    min-height: 28px;
+    font-size: 12px;
 }
 QPushButton:hover {
     background-color: rgba(148, 163, 184, 0.32);


### PR DESCRIPTION
## Summary
- shrink the footer notice text styling to lower its visual height
- give the report issue button a dedicated style to reduce its padding and minimum height

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68db7ac4a08c832ba3249ac0705c185c