### PR TITLE
Fix PDF font scaling

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from sklearn.cluster import KMeans
 from datetime import datetime
 from html import escape
 
-from PyQt6.QtCore import Qt, QMarginsF
+from PyQt6.QtCore import Qt, QMarginsF, QSizeF
 from PyQt6.QtGui import (
     QKeySequence,
     QShortcut,
@@ -3231,8 +3231,12 @@ QHeaderView::section {
         document.setHtml(html)
 
         writer = QPdfWriter(str(file_path))
+        writer.setResolution(96)
         writer.setPageSize(QPageSize(QPageSize.PageSizeId.A4))
         writer.setPageMargins(QMarginsF(12, 12, 12, 12))
+
+        layout_rect = writer.pageLayout().paintRectPixels(writer.resolution())
+        document.setPageSize(QSizeF(layout_rect.size()))
 
         document.print(writer)
 


### PR DESCRIPTION
## Summary
- ensure PDF reports render at screen-friendly resolution
- align QTextDocument page size with PDF layout to avoid shrunken text

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68db7b974c44832b94447889405bb9b3