### PR TITLE
Embed inline YouTube previews for songs

### DIFF
--- a/main.py
+++ b/main.py
@@ -2274,95 +2274,61 @@ def build_track_preview_html(embed_url: str) -> str:
 """
 
 
-class TrackPreviewWidget(QFrame):
-    def __init__(self, parent: Optional[QWidget] = None):
+class SongPreviewEmbed(QFrame):
+    def __init__(self, parent: Optional[QWidget] = None, minimum_height: int = 200):
         super().__init__(parent)
-        self.setObjectName("TrackPreviewWidget")
+        self.setObjectName("SongPreviewEmbed")
         self.setFrameShape(QFrame.Shape.NoFrame)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(16, 16, 16, 16)
-        layout.setSpacing(10)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
 
-        self.header_label = QLabel("곡 미리 듣기")
-        self.header_label.setObjectName("SectionSubtitle")
-        layout.addWidget(self.header_label)
-
-        self.status_label = QLabel()
-        self.status_label.setObjectName("BodyLabel")
-        self.status_label.setWordWrap(True)
-        layout.addWidget(self.status_label)
+        self.caption_label = QLabel()
+        self.caption_label.setObjectName("BodyLabel")
+        self.caption_label.setWordWrap(True)
+        layout.addWidget(self.caption_label)
 
         self.web_view: Optional[QWebEngineView] = None
         if WEB_ENGINE_AVAILABLE:
             self.web_view = QWebEngineView()
-            self.web_view.setObjectName("TrackPreviewView")
-            self.web_view.setMinimumHeight(260)
-            layout.addWidget(self.web_view, 1)
+            self.web_view.setObjectName("SongPreviewEmbedView")
+            self.web_view.setMinimumHeight(minimum_height)
+            layout.addWidget(self.web_view)
 
         self.current_song: Optional[Song] = None
 
-        self.reset()
+        self.set_song(None)
 
-    def is_available(self) -> bool:
-        return self.web_view is not None
+    def set_song(self, song: Optional[Song]) -> None:
+        self.current_song = song
 
-    def reset(self, message: Optional[str] = None) -> None:
-        self.current_song = None
-        if self.web_view:
-            self.web_view.setUrl(QUrl("about:blank"))
-        if not self.is_available():
-            self.status_label.setText(
-                "미리 듣기를 지원하려면 PyQt6-WebEngine이 필요합니다. 환경 설정을 확인해주세요."
-            )
-            return
-        if message:
-            self.status_label.setText(message)
-        else:
-            self.status_label.setText("미리 듣기 버튼을 누르면 곡을 재생합니다.")
-
-    def prepare_for_match(self, songs: List[Song]) -> None:
-        titles = " vs ".join(f"{song.artist} - {song.get_display_title()}" for song in songs if song)
-        if not titles:
-            self.reset()
-            return
-        self.reset(f"{titles}\n원하는 곡의 미리 듣기 버튼을 눌러보세요.")
-
-    def can_preview(self, song: Optional[Song]) -> bool:
         if not song:
-            return False
-        if not self.is_available():
-            return False
-        return build_youtube_embed_url(song.youtube_url) is not None
-
-    def unavailable_message(self, song: Optional[Song] = None) -> str:
-        if not self.is_available():
-            return "이 환경에서는 미리 듣기를 사용할 수 없습니다. PyQt6-WebEngine을 설치해주세요."
-        if not song or not song.youtube_url:
-            return "이 곡은 미리 듣기 링크가 제공되지 않았습니다."
-        return "이 곡의 링크는 미리 듣기 형식으로 변환할 수 없습니다."
-
-    def load_song(self, song: Optional[Song]) -> None:
-        if not song:
-            self.reset()
+            self._show_message("미리 볼 곡이 없습니다.")
             return
 
-        if not self.can_preview(song):
-            self.status_label.setText(self.unavailable_message(song))
-            if self.web_view:
-                self.web_view.setUrl(QUrl("about:blank"))
+        if not song.youtube_url:
+            self._show_message("이 곡은 영상 미리보기를 지원하지 않습니다.")
             return
 
         embed_url = build_youtube_embed_url(song.youtube_url)
-        if not embed_url or not self.web_view:
-            self.status_label.setText(self.unavailable_message(song))
+        if not embed_url:
+            self._show_message("이 곡의 링크는 영상 미리보기 형식으로 변환할 수 없습니다.")
             return
 
-        self.current_song = song
-        self.status_label.setText(f"{song.artist} - {song.get_display_title()} 미리 듣는 중…")
+        if not self.web_view:
+            self._show_message("이 환경에서는 영상 미리보기를 사용할 수 없습니다. PyQt6-WebEngine을 설치해주세요.")
+            return
+
         preview_html = build_track_preview_html(embed_url)
         self.web_view.setHtml(preview_html, QUrl("https://www.youtube.com"))
+        self.caption_label.setText(f"{song.artist} - {song.get_display_title()} 영상 미리보기")
+
+    def _show_message(self, message: str) -> None:
+        self.caption_label.setText(message)
+        if self.web_view:
+            self.web_view.setUrl(QUrl("about:blank"))
 
 
 class MusicTournamentGUI(QMainWindow):
@@ -2497,7 +2463,6 @@ class MusicTournamentGUI(QMainWindow):
         self.stage_summary_label: Optional[QLabel] = None
         self.unlocked_stages: Set[str] = {"start", "survey"}
         self.active_stage = "start"
-        self.preview_widget = TrackPreviewWidget()
 
         central = QWidget()
         central.setObjectName("CentralWidget")
@@ -3034,11 +2999,6 @@ QHeaderView::section {
             item = self.content_layout.takeAt(0)
             widget = item.widget()
             if widget is not None:
-                if widget is self.preview_widget:
-                    self.preview_widget.reset()
-                    self.preview_widget.setParent(None)
-                    self.preview_widget.hide()
-                    continue
                 widget.deleteLater()
 
     def show_start_view(self):
@@ -3433,12 +3393,6 @@ QHeaderView::section {
         cards_layout.addWidget(self.card_b["box"], 1)
         layout.addWidget(cards_container)
 
-        if self.preview_widget:
-            self.preview_widget.setParent(container)
-            self.preview_widget.reset("토너먼트 곡의 미리 듣기를 이 영역에서 확인할 수 있습니다.")
-            self.preview_widget.show()
-            layout.addWidget(self.preview_widget)
-
         self.helper_label = QLabel("키보드 A/B/T/S로도 선택할 수 있어요.")
         self.helper_label.setProperty("role", "helper")
         self.helper_label.setWordWrap(True)
@@ -3625,7 +3579,7 @@ QHeaderView::section {
             return "과" if code % 28 != 0 else "와"
         return "와"
 
-    def create_song_card(self, parent: QWidget, title: str, side: str):
+    def create_song_card(self, parent: QWidget, title: str, side: str) -> Dict[str, Any]:
         box = QGroupBox(title)
         box.setObjectName("SongCard")
         box.setProperty("side", side)
@@ -3642,25 +3596,18 @@ QHeaderView::section {
         tag_label.setProperty("role", "helper")
         tag_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.MinimumExpanding)
         layout.addWidget(tag_label)
-        preview_button = QPushButton("미리 듣기")
-        preview_button.setCursor(Qt.CursorShape.PointingHandCursor)
-        preview_button.clicked.connect(lambda _=False, s=side: self.handle_preview_request(s))
-        layout.addWidget(preview_button)
-        preview_info = QLabel()
-        preview_info.setWordWrap(True)
-        preview_info.setProperty("role", "helper")
-        layout.addWidget(preview_info)
+        preview_embed = SongPreviewEmbed(box, minimum_height=160)
+        layout.addWidget(preview_embed)
         return {
             "box": box,
             "title": name_label,
             "meta": meta_label,
             "tag": tag_label,
-            "preview_button": preview_button,
-            "preview_info": preview_info,
+            "preview_embed": preview_embed,
         }
 
 
-    def update_song_card(self, card: Dict[str, QLabel], song: Song):
+    def update_song_card(self, card: Dict[str, Any], song: Song) -> None:
         card["title"].setText(song.get_display_title())
         rating = song.rating if song.rating else 1500
         card["meta"].setText(f"{song.artist} · 예상 레이팅 {rating:.0f}")
@@ -3673,26 +3620,7 @@ QHeaderView::section {
         if highlight:
             lines.append(highlight)
         card["tag"].setText("\n".join(lines))
-        supports_preview = self.preview_widget.can_preview(song) if self.preview_widget else False
-        card["preview_button"].setEnabled(supports_preview)
-        if supports_preview:
-            card["preview_button"].setToolTip("YouTube 미리 듣기를 재생합니다.")
-            card["preview_info"].setText("미리 듣기 버튼을 누르면 브라우저 내에서 바로 재생됩니다.")
-        else:
-            card["preview_button"].setToolTip("")
-            card["preview_info"].setText(self.preview_widget.unavailable_message(song) if self.preview_widget else "")
-
-    def handle_preview_request(self, side: str):
-        if not self.preview_widget:
-            return
-        if not self.active_match:
-            self.preview_widget.reset()
-            return
-        if side == "A":
-            song = self.active_match.song_a
-        else:
-            song = self.active_match.song_b
-        self.preview_widget.load_song(song)
+        card["preview_embed"].set_song(song)
 
     def display_current_match(self):
         if not self.current_round_matches:
@@ -3723,8 +3651,6 @@ QHeaderView::section {
             self.progress_summary_label.setText(
                 f"전체 {self.total_matches} 매치 중 {played} 완료 · 다음 선택: {match.match_id}"
             )
-        if self.preview_widget:
-            self.preview_widget.prepare_for_match([match.song_a, match.song_b])
 
     def on_choice(self, choice: str):
         if not self.active_match or not self.engine:
@@ -3801,12 +3727,6 @@ QHeaderView::section {
         recommender = RecommendationEngine(self.songs, self.candidates, self.survey_profile)
         self.recommendations = recommender.generate_recommendations(self.report["top_songs"])
 
-        if self.preview_widget:
-            self.preview_widget.setParent(container)
-            self.preview_widget.reset("추천곡의 미리 듣기 버튼을 누르면 이 영역에서 재생됩니다.")
-            self.preview_widget.show()
-            layout.addWidget(self.preview_widget)
-
         summary_card = QFrame()
         summary_card.setObjectName("InsightCard")
         summary_layout = QVBoxLayout(summary_card)
@@ -3831,22 +3751,9 @@ QHeaderView::section {
             summary_label.setWordWrap(True)
             summary_layout.addWidget(summary_label)
 
-        if self.champion.youtube_url:
-            champion_preview = QPushButton("우승 곡 미리 듣기")
-            champion_preview.setCursor(Qt.CursorShape.PointingHandCursor)
-            champion_preview.clicked.connect(lambda _=False, s=self.champion: self.preview_widget.load_song(s))
-            supports_preview = self.preview_widget.can_preview(self.champion) if self.preview_widget else False
-            champion_preview.setEnabled(supports_preview)
-            summary_layout.addWidget(champion_preview)
-            helper = QLabel()
-            helper.setObjectName("BodyLabel")
-            helper.setProperty("role", "helper")
-            helper.setWordWrap(True)
-            if supports_preview:
-                helper.setText("버튼을 누르면 상단 미리 듣기 영역에서 우승 곡이 재생됩니다.")
-            else:
-                helper.setText(self.preview_widget.unavailable_message(self.champion) if self.preview_widget else "미리 듣기를 지원하지 않는 환경입니다.")
-            summary_layout.addWidget(helper)
+        champion_embed = SongPreviewEmbed(summary_card, minimum_height=200)
+        champion_embed.set_song(self.champion)
+        summary_layout.addWidget(champion_embed)
 
         if self.report["top_songs"]:
             playlist_label = QLabel("상위 플레이리스트")
@@ -4359,21 +4266,9 @@ QHeaderView::section {
                 reason_label.setProperty("role", "helper")
                 reason_label.setWordWrap(True)
                 card_layout.addWidget(reason_label)
-                preview_button = QPushButton("미리 듣기")
-                preview_button.setCursor(Qt.CursorShape.PointingHandCursor)
-                preview_button.clicked.connect(lambda _=False, s=song: self.preview_widget.load_song(s))
-                supports_preview = self.preview_widget.can_preview(song) if self.preview_widget else False
-                preview_button.setEnabled(supports_preview)
-                helper = QLabel()
-                helper.setObjectName("BodyLabel")
-                helper.setProperty("role", "helper")
-                helper.setWordWrap(True)
-                if supports_preview:
-                    helper.setText("버튼을 누르면 상단 미리 듣기 영역에서 재생됩니다.")
-                else:
-                    helper.setText(self.preview_widget.unavailable_message(song) if self.preview_widget else "미리 듣기를 지원하지 않는 환경입니다.")
-                card_layout.addWidget(preview_button)
-                card_layout.addWidget(helper)
+                embed = SongPreviewEmbed(card, minimum_height=160)
+                embed.set_song(song)
+                card_layout.addWidget(embed)
             card_layout.addSpacing(6)
         layout.addWidget(card)
 


### PR DESCRIPTION
## Summary
- replace the shared preview panel with a SongPreviewEmbed component that auto-loads YouTube videos for individual tracks
- display embedded previews directly inside tournament cards, the champion summary, and recommendation entries
- provide contextual fallback messaging when YouTube embeds cannot be loaded

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68ddf34b778c832ba89cf018a6879b4f