### PR TITLE
Remove unsupported web-share permission from embedded YouTube player

### DIFF
--- a/main.py
+++ b/main.py
@@ -2259,7 +2259,15 @@ def build_track_preview_html(embed_url: str) -> str:
             const iframe = document.createElement('iframe');
             iframe.src = embedUrl;
             iframe.title = 'YouTube video player';
-            iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share');
+            const featurePermissions = [
+                'accelerometer',
+                'autoplay',
+                'clipboard-write',
+                'encrypted-media',
+                'gyroscope',
+                'picture-in-picture'
+            ];
+            iframe.setAttribute('allow', featurePermissions.join('; '));
             iframe.allowFullscreen = true;
             container.appendChild(iframe);
             container.dataset.initialized = 'true';


### PR DESCRIPTION
## Summary
- remove the unsupported `web-share` feature permission from the embedded YouTube iframe
- centralize the allow list of iframe feature permissions for clarity and future adjustments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf8c2057c832b9e0c071ea50e647a